### PR TITLE
Fix/checkstyle warnings

### DIFF
--- a/app/controllers/v1/EditController.scala
+++ b/app/controllers/v1/EditController.scala
@@ -67,7 +67,7 @@ class EditController @Inject() (ws: RequestGenerator, val configuration: Configu
 
   def rerouteEditPost(jsonBody: Option[String], url: String): Future[Result] = {
     jsonBody.map { text =>
-      ws.controlReroute(url, "Content-Type" -> "application/json", Json.parse(text.toString)).map {
+      ws.controlReroute(url, "Content-Type" -> "application/json", Json.parse(text)).map {
         response => Status(response.status)(response.body)
       }
     }.getOrElse {

--- a/app/services/RequestGenerator.scala
+++ b/app/services/RequestGenerator.scala
@@ -52,15 +52,15 @@ class RequestGenerator @Inject() (
       .flashing("redirect" -> s"You are being redirected to $route route", "status" -> "ok")
   }
 
-  def singleGETRequest(path: String, headers: Seq[(String, String)] = Seq(), params: Seq[(String, String)] = Seq()): Future[WSResponse] =
-    ws.url(path.toString)
+  def singleGETRequest(path: String, headers: Seq[(String, String)] = Seq.empty, params: Seq[(String, String)] = Seq.empty): Future[WSResponse] =
+    ws.url(path)
       .withQueryString(params: _*)
       .withHeaders(headers: _*)
       .withRequestTimeout(Duration(TIMEOUT_REQUEST, DURATION_METRIC))
       .get
 
   def singleGETRequestWithTimeout(url: String, timeout: Duration = Duration(TIMEOUT_REQUEST, DURATION_METRIC)): WSResponse =
-    Await.result(ws.url(url.toString).get(), timeout)
+    Await.result(ws.url(url).get(), timeout)
 
   @deprecated("Migrate to singlePOSTRequest", "27 Nov 2017 - fix/tidy-up-1")
   def controlReroute(url: String, headers: (String, String), body: JsValue): Future[WSResponse] = {
@@ -70,7 +70,7 @@ class RequestGenerator @Inject() (
 
   def singlePOSTRequest(url: String, headers: (String, String), body: JsValue): Future[WSResponse] = {
     LOGGER.debug(s"Rerouting to route: $url")
-    ws.url(url.toString)
+    ws.url(url)
       .withHeaders(headers)
       .withRequestTimeout(Duration(TIMEOUT_REQUEST, DURATION_METRIC))
       .post(body)

--- a/app/utils/Utilities.scala
+++ b/app/utils/Utilities.scala
@@ -32,16 +32,6 @@ object Utilities {
     )
   }
 
-  def getElement(value: AnyRef) = {
-    val res = value match {
-      case None => ""
-      case Some(i: Int) => i
-      case Some(l: Long) => l
-      case Some(z) => s"""${z.toString}"""
-    }
-    res
-  }
-
   def unquote(s: String) = s.replace("\"", "")
 
   implicit class orElseNull(val j: JsLookupResult) {

--- a/test/unit/UtilitiesTestSpec.scala
+++ b/test/unit/UtilitiesTestSpec.scala
@@ -28,15 +28,6 @@ class UtilitiesTestSpec extends TestUtils {
     }
   }
 
-  "getElement" should {
-    "return a Long for Option[Long]" in {
-      val expected = 5784785784L
-      val get = getElement(Some(expected))
-      get must not be a[Option[Long]]
-      get mustEqual expected
-    }
-  }
-
   "unquote" should {
     "removes any unnecessary quotes" in {
       val quoted = """hello this is a\" test"""


### PR DESCRIPTION
Checkstyle warnings fixes

- Changed interpolated strings to strings where the contents was just a string.
- Removed getElement method as it was causing a warning and not needed.
- Changed Seq() to Seq.empty where preferred.