### PR TITLE
REG-1137: Refactor Companies House to share common 'admin data' approach

### DIFF
--- a/app/Module.scala
+++ b/app/Module.scala
@@ -10,7 +10,7 @@ import play.api.libs.json.{ Reads, Writes }
 import play.api.libs.ws.WSClient
 import play.api.mvc.Result
 import play.api.{ Configuration, Environment }
-import repository.DataSourceNames.{ Paye, SbrCtrl, Vat }
+import repository.DataSourceNames.{ CompaniesHouse, Paye, SbrCtrl, Vat }
 import repository._
 import repository.admindata.RestAdminDataRepository
 import repository.rest.{ RestUnitRepository, RestUnitRepositoryConfig, UnitRepository }
@@ -19,7 +19,7 @@ import services.LinkedUnitService
 import services.admindata.AdminDataService
 import services.sbrctrl.SbrCtrlEnterpriseService
 import uk.gov.ons.sbr.models._
-import unitref.{ PayeUnitRef, VatUnitRef }
+import unitref.{ CompaniesHouseUnitRef, PayeUnitRef, VatUnitRef }
 
 /**
  * This class is a Guice module that tells Guice how to bind several
@@ -48,17 +48,22 @@ class Module(
     val restRepositoryConfigLoader = BaseUrlConfigLoader.map(RestUnitRepositoryConfig)
 
     // sbr repositories
-    val sbrCtrlRestRepositoryConfig = SbrCtrlRestUnitRepositoryConfigLoader(restRepositoryConfigLoader, underlyingConfig)
-    bind(classOf[RestUnitRepositoryConfig]).annotatedWith(named(SbrCtrl)).toInstance(sbrCtrlRestRepositoryConfig)
+    bind(classOf[RestUnitRepositoryConfig]).annotatedWith(named(SbrCtrl)).toInstance(
+      SbrCtrlRestUnitRepositoryConfigLoader(restRepositoryConfigLoader, underlyingConfig)
+    )
     bind(classOf[UnitLinksRepository]).to(classOf[RestUnitLinksRepository])
     bind(classOf[EnterpriseRepository]).to(classOf[RestEnterpriseRepository])
 
     // config for admin data repositories
-    val vatRestRepositoryConfig = RestAdminDataRepositoryConfigLoader.vat(restRepositoryConfigLoader, underlyingConfig)
-    bind(classOf[RestUnitRepositoryConfig]).annotatedWith(named(Vat)).toInstance(vatRestRepositoryConfig)
-
-    val payeRestRepositoryConfig = RestAdminDataRepositoryConfigLoader.paye(restRepositoryConfigLoader, underlyingConfig)
-    bind(classOf[RestUnitRepositoryConfig]).annotatedWith(named(Paye)).toInstance(payeRestRepositoryConfig)
+    bind(classOf[RestUnitRepositoryConfig]).annotatedWith(named(Vat)).toInstance(
+      RestAdminDataRepositoryConfigLoader.vat(restRepositoryConfigLoader, underlyingConfig)
+    )
+    bind(classOf[RestUnitRepositoryConfig]).annotatedWith(named(Paye)).toInstance(
+      RestAdminDataRepositoryConfigLoader.paye(restRepositoryConfigLoader, underlyingConfig)
+    )
+    bind(classOf[RestUnitRepositoryConfig]).annotatedWith(named(CompaniesHouse)).toInstance(
+      RestAdminDataRepositoryConfigLoader.companiesHouse(restRepositoryConfigLoader, underlyingConfig)
+    )
 
     // generics
     /*
@@ -71,6 +76,7 @@ class Module(
     bind(new TypeLiteral[Writes[LinkedUnit]]() {}).toInstance(LinkedUnit.writes)
     bind(new TypeLiteral[LinkedUnitRetrievalHandler[Result]]() {}).to(classOf[HttpLinkedUnitRetrievalHandler])
     bind(new TypeLiteral[LinkedUnitService[Ern]]() {}).to(classOf[SbrCtrlEnterpriseService])
+
     /*
      * Explicitly return unit to avoid warning about discarded non-Unit value.
      * This is because a .to(classOf[...]) invocation returns a ScopedBindingBuilder which is
@@ -98,6 +104,12 @@ class Module(
     new RestAdminDataRepository(unitRepository, readsAdminData)
   }
 
+  @Provides @Named(CompaniesHouse)
+  def providesCompaniesHouseAdminDataRepository(@Inject()@Named(CompaniesHouse) chUnitRepositoryConfig: RestUnitRepositoryConfig, wSClient: WSClient, readsAdminData: Reads[AdminData]): AdminDataRepository = {
+    val unitRepository = new RestUnitRepository(chUnitRepositoryConfig, wSClient)
+    new RestAdminDataRepository(unitRepository, readsAdminData)
+  }
+
   // services
   @Provides
   def providesVatService(@Inject() unitLinksRepository: UnitLinksRepository, @Named(Vat) vatRepository: AdminDataRepository): LinkedUnitService[VatRef] =
@@ -106,6 +118,10 @@ class Module(
   @Provides
   def providesPayeService(@Inject() unitLinksRepository: UnitLinksRepository, @Named(Paye) payeRepository: AdminDataRepository): LinkedUnitService[PayeRef] =
     new AdminDataService[PayeRef](PayeUnitRef, unitLinksRepository, payeRepository)
+
+  @Provides
+  def providesCompaniesHouseService(@Inject() unitLinksRepository: UnitLinksRepository, @Named(CompaniesHouse) chRepository: AdminDataRepository): LinkedUnitService[CompanyRefNumber] =
+    new AdminDataService[CompanyRefNumber](CompaniesHouseUnitRef, unitLinksRepository, chRepository)
 
   // controller actions
   @Provides
@@ -119,4 +135,8 @@ class Module(
   @Provides
   def providesPayeLinkedUnitRequestActionBuilderMaker(@Inject() payeService: LinkedUnitService[PayeRef]): LinkedUnitRequestActionBuilderMaker[PayeRef] =
     new RetrieveLinkedUnitAction[PayeRef](payeService)
+
+  @Provides
+  def providesCompaniesHouseLinkedUnitRequestActionBuilderMaker(@Inject() chService: LinkedUnitService[CompanyRefNumber]): LinkedUnitRequestActionBuilderMaker[CompanyRefNumber] =
+    new RetrieveLinkedUnitAction[CompanyRefNumber](chService)
 }

--- a/app/config/RestAdminDataRepositoryConfigLoader.scala
+++ b/app/config/RestAdminDataRepositoryConfigLoader.scala
@@ -18,4 +18,7 @@ object RestAdminDataRepositoryConfigLoader {
 
   def paye(restUnitRepositoryConfigLoader: ConfigLoader[RestUnitRepositoryConfig], rootConfig: Config): RestUnitRepositoryConfig =
     restUnitRepositoryConfigLoader.load(config = rootConfig, path = s"$adminDataPath.paye")
+
+  def companiesHouse(restUnitRepositoryConfigLoader: ConfigLoader[RestUnitRepositoryConfig], rootConfig: Config): RestUnitRepositoryConfig =
+    restUnitRepositoryConfigLoader.load(config = rootConfig, path = s"$adminDataPath.ch")
 }

--- a/app/controllers/v1/CompaniesHouseController.scala
+++ b/app/controllers/v1/CompaniesHouseController.scala
@@ -1,0 +1,62 @@
+package controllers.v1
+
+import actions.RetrieveLinkedUnitAction.LinkedUnitRequestActionBuilderMaker
+import handlers.LinkedUnitRetrievalHandler
+import io.swagger.annotations.{ Api, _ }
+import javax.inject.{ Inject, Singleton }
+import play.api.libs.json.JsObject
+import play.api.mvc.{ Action, AnyContent, Result }
+import uk.gov.ons.sbr.models.{ CompanyRefNumber, Period, UnitId, UnitType }
+import unitref.CompaniesHouseUnitRef
+
+@Api("Companies House")
+@Singleton
+class CompaniesHouseController @Inject() (
+    retrieveLinkedUnitAction: LinkedUnitRequestActionBuilderMaker[CompanyRefNumber],
+    handleLinkedUnitRetrievalResult: LinkedUnitRetrievalHandler[Result]
+) extends LinkedUnitController[CompanyRefNumber](CompaniesHouseUnitRef, retrieveLinkedUnitAction, handleLinkedUnitRetrievalResult) {
+  @ApiOperation(
+    value = "Json representation of the Companies House unit along with its links to other units",
+    notes = "parents represent a mapping from a parent unitType to the associated unit identifier; " +
+    "vars simply passes through the variables defined by the admin data (and so is not defined here)",
+    response = classOf[ch.examples.CompaniesHouseLinkedUnitForSwagger],
+    code = 200,
+    httpMethod = "GET"
+  )
+  @ApiResponses(Array(
+    new ApiResponse(code = 400, message = "One or more arguments do not comply with the expected format"),
+    new ApiResponse(code = 404, message = "Either a Companies House unit could not be found with the specified company reference number and Period, or no related unit links are defined"),
+    new ApiResponse(code = 500, message = "The attempt to retrieve the Companies House unit could not complete due to an unrecoverable error"),
+    new ApiResponse(code = 504, message = "A response was not received from a data server within the required time interval")
+  ))
+  def retrieveCompaniesHouseLinkedUnit(
+    @ApiParam(value = "Period (unit load date) - in YYYYMM format", example = "201803", required = true) periodStr: String,
+    @ApiParam(value = "Company reference number - an eight digit number", example = "12345678", required = true) crnStr: String
+  ): Action[AnyContent] =
+    retrieveLinkedUnit(periodStr, crnStr)
+}
+
+/*
+ * DO NOT USE.
+ * These are only defined to help Swagger generate a suitable example of a Companies House response.
+ *
+ * Note that we are using a nested package to isolate these classes.  Attempts to use nested classes caused issues,
+ * because they must be specified to Swagger in Java format (parentname$childname) but the $ symbol generates warnings
+ * in Scala about a possible interpolation error, and Scala has no support for suppressing individual warnings.
+ */
+package ch.examples {
+  @deprecated(message = "This is just for Swagger example purposes - do not use in real code", since = "")
+  case class CompaniesHouseParentForSwagger(
+    @ApiModelProperty(value = "the unit type of the parent followed by the parent's unique identifier", dataType = "string", example = "1020541592", required = true) ENT: String,
+    @ApiModelProperty(value = "the unit type of the parent followed by the parent's unique identifier", dataType = "string", example = "1234567890123456", required = true) LEU: String
+  )
+
+  @deprecated(message = "This is just for Swagger example purposes - do not use in real code", since = "")
+  case class CompaniesHouseLinkedUnitForSwagger(
+    @ApiModelProperty(value = "the Companies House company reference number", dataType = "string", example = "12345678", required = true) id: UnitId,
+    @ApiModelProperty(value = "the type of unit", dataType = "string", example = "CH", required = true) unitType: UnitType,
+    @ApiModelProperty(value = "Period (unit load date) - in YYYYMM format", dataType = "string", example = "201803", required = true) period: Period,
+    @ApiModelProperty(value = "the types of parent units along with the associated unit identifiers", dataType = "controllers.v1.ch.examples.CompaniesHouseParentForSwagger", required = false) parents: Option[Map[UnitType, UnitId]],
+    @ApiModelProperty(value = "the representation of the unit itself", dataType = "object", required = true) vars: JsObject
+  )
+}

--- a/app/repository/DataSourceNames.scala
+++ b/app/repository/DataSourceNames.scala
@@ -8,4 +8,5 @@ object DataSourceNames {
   final val SbrCtrl = "sbr-ctrl"
   final val Vat = "vat"
   final val Paye = "paye"
+  final val CompaniesHouse = "ch"
 }

--- a/app/uk/gov/ons/sbr/models/CompanyRefNumber.scala
+++ b/app/uk/gov/ons/sbr/models/CompanyRefNumber.scala
@@ -1,0 +1,3 @@
+package uk.gov.ons.sbr.models
+
+case class CompanyRefNumber(value: String)

--- a/app/unitref/CompaniesHouseUnitRef.scala
+++ b/app/unitref/CompaniesHouseUnitRef.scala
@@ -1,0 +1,15 @@
+package unitref
+
+import uk.gov.ons.sbr.models.UnitType.CompaniesHouse
+import uk.gov.ons.sbr.models.{ CompanyRefNumber, UnitId, UnitType }
+
+object CompaniesHouseUnitRef extends UnitRef[CompanyRefNumber] {
+  override def fromString(value: String): CompanyRefNumber =
+    CompanyRefNumber(value)
+
+  override def toIdTypePair(ref: CompanyRefNumber): (UnitId, UnitType) =
+    toUnitId(ref) -> CompaniesHouse
+
+  override def toUnitId(ref: CompanyRefNumber): UnitId =
+    UnitId(ref.value)
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -440,6 +440,15 @@ api {
         port = 9005
         port = ${?ONS_SBR_PAYE_ADMIN_DATA_API_PORT}
       }
+
+      ch {
+        protocol = "http"
+        protocol = ${?ONS_SBR_CH_ADMIN_DATA_API_PROTOCOL}
+        host = "localhost"
+        host = ${?ONS_SBR_CH_ADMIN_DATA_API_HOST}
+        port = 9005
+        port = ${?ONS_SBR_CH_ADMIN_DATA_API_PORT}
+      }
     }
   }
 }

--- a/conf/routes
+++ b/conf/routes
@@ -17,9 +17,11 @@ GET     /v1/periods/:period/vats/:vatref                                controll
 GET     /v1/periods/$period<\d{4}(0[1-9]|1[0-2])>/payes/$payeref<[0-9a-zA-Z]{4,12}> controllers.v1.PayeController.retrievePayeLinkedUnit(period, payeref)
 GET     /v1/periods/:period/payes/:payeref                                          controllers.BadRequestController.badRequest(period, payeref)
 
+GET     /v1/periods/$period<\d{4}(0[1-9]|1[0-2])>/crns/$crn<\d{8}>      controllers.v1.CompaniesHouseController.retrieveCompaniesHouseLinkedUnit(period, crn)
+GET     /v1/periods/:period/crns/:crn                                   controllers.BadRequestController.badRequest(period, crn)
+
 GET     /v1/periods/:date/leus/:id      controllers.v1.SearchController.searchLeUWithPeriod(date, id)
 GET     /v1/periods/:date/lous/:id      controllers.v1.LocalUnitController.searchLoUWithPeriod(date, id)
-GET     /v1/periods/:date/crns/:id      controllers.v1.SearchController.searchCrnWithPeriod(date, id)
 
 # Editing Endpoints
 POST    /v1/enterprises/:id                  controllers.v1.EditController.editEnterprise(id)

--- a/test/config/RestAdminDataRepositoryConfigLoaderSpec.scala
+++ b/test/config/RestAdminDataRepositoryConfigLoaderSpec.scala
@@ -31,6 +31,12 @@ class RestAdminDataRepositoryConfigLoaderSpec extends FreeSpec with Matchers wit
 
         RestAdminDataRepositoryConfigLoader.paye(restUnitRepositoryConfigLoader, TheConfig) shouldBe SomeRestUnitRepositoryConfig
       }
+
+      "can be loaded for Companies House" in new Fixture {
+        (restUnitRepositoryConfigLoader.load _).expects(TheConfig, "api.admin.data.ch").returning(SomeRestUnitRepositoryConfig)
+
+        RestAdminDataRepositoryConfigLoader.companiesHouse(restUnitRepositoryConfigLoader, TheConfig) shouldBe SomeRestUnitRepositoryConfig
+      }
     }
 
     "cannot be loaded when it contains an invalid configuration" in new Fixture {

--- a/test/controllers/v1/CompaniesHouseRoutingSpec.scala
+++ b/test/controllers/v1/CompaniesHouseRoutingSpec.scala
@@ -1,0 +1,141 @@
+package controllers.v1
+
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{ FreeSpec, Matchers }
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import support.matchers.HttpServerErrorStatusCodeMatcher.aServerError
+
+/*
+ * We are relying on the router to perform argument validation for us (via regex constraints).
+ * This spec tests that the router is configured correctly.
+ *
+ * Because we are relying on the router to validate arguments, and the simple routes file configuration does not
+ * compose, each and every route must be tested individually.  In addition, some of the regex are non-trivial,
+ * and as the saying goes:
+ *
+ *     "Some people, when confronted with a problem, think 'I know, I'll use regular expressions.'
+ *     Now they have two problems."
+ *
+ * For example, in order to fully test the period regex, we test that each and every possible month is considered
+ * valid.  These are downsides of this "router based validation" approach ...
+ */
+class CompaniesHouseRoutingSpec extends FreeSpec with Matchers with GuiceOneAppPerSuite with ScalaFutures {
+
+  /*
+   * When valid arguments are routed to the retrieve... actions, an attempt will be made to make a call to
+   * sbr-control-api.  However, we do not prime a response in this spec, as we are only concerned with routing.
+   * We therefore override the HTTP timeout configuration to minimise the time this spec waits on a connection that
+   * we know cannot be established.
+   */
+  override def fakeApplication(): Application = new GuiceApplicationBuilder().configure(Map("play.ws.timeout.connection" -> "50")).build()
+
+  private trait Fixture {
+    val ValidCompanyRefNumber = "04447084"
+    val ValidPeriod = "201805"
+  }
+
+  "A request to retrieve a Companies House unit by company reference number and period" - {
+    "is rejected when" - {
+      "the company reference number" - {
+        "has fewer than eight digits" in new Fixture {
+          val CompanyRefNumberTooFewDigits = ValidCompanyRefNumber.drop(1)
+
+          val Some(result) = route(app, FakeRequest(GET, s"/v1/periods/$ValidPeriod/crns/$CompanyRefNumberTooFewDigits"))
+
+          status(result) shouldBe BAD_REQUEST
+        }
+
+        "has more than eight digits" in new Fixture {
+          val CompanyRefNumberTooManyDigits = ValidCompanyRefNumber + "9"
+
+          val Some(result) = route(app, FakeRequest(GET, s"/v1/periods/$ValidPeriod/crns/$CompanyRefNumberTooManyDigits"))
+
+          status(result) shouldBe BAD_REQUEST
+        }
+
+        "is non-numeric" in new Fixture {
+          val CompanyRefNumberNonNumeric = new String(Array.fill(8)('A'))
+
+          val Some(result) = route(app, FakeRequest(GET, s"/v1/periods/$ValidPeriod/crns/$CompanyRefNumberNonNumeric"))
+
+          status(result) shouldBe BAD_REQUEST
+        }
+      }
+
+      "the Period" - {
+        "has fewer than six digits" in new Fixture {
+          val PeriodTooFewDigits = ValidPeriod.drop(1)
+
+          val Some(result) = route(app, FakeRequest(GET, s"/v1/periods/$PeriodTooFewDigits/crns/$ValidCompanyRefNumber"))
+
+          status(result) shouldBe BAD_REQUEST
+        }
+
+        "has more than six digits" in new Fixture {
+          val PeriodTooManyDigits = ValidPeriod + "1"
+
+          val Some(result) = route(app, FakeRequest(GET, s"/v1/periods/$PeriodTooManyDigits/crns/$ValidCompanyRefNumber"))
+
+          status(result) shouldBe BAD_REQUEST
+        }
+
+        "is non-numeric" in new Fixture {
+          val PeriodNonNumeric = new String(Array.fill(6)('A'))
+
+          val Some(result) = route(app, FakeRequest(GET, s"/v1/periods/$PeriodNonNumeric/crns/$ValidCompanyRefNumber"))
+
+          status(result) shouldBe BAD_REQUEST
+        }
+
+        "is negative" in new Fixture {
+          val PeriodNegative = "-01801"
+
+          val Some(result) = route(app, FakeRequest(GET, s"/v1/periods/$PeriodNegative/crns/$ValidCompanyRefNumber"))
+
+          status(result) shouldBe BAD_REQUEST
+        }
+
+        "has an invalid month value" - {
+          "that is too low" in new Fixture {
+            val PeriodInvalidBeforeCalendarMonth = "201800"
+
+            val Some(result) = route(app, FakeRequest(GET, s"/v1/periods/$PeriodInvalidBeforeCalendarMonth/crns/$ValidCompanyRefNumber"))
+
+            status(result) shouldBe BAD_REQUEST
+          }
+
+          "that is too high" in new Fixture {
+            val PeriodInvalidAfterCalendarMonth = "201813"
+
+            val Some(result) = route(app, FakeRequest(GET, s"/v1/periods/$PeriodInvalidAfterCalendarMonth/crns/$ValidCompanyRefNumber"))
+
+            status(result) shouldBe BAD_REQUEST
+          }
+        }
+      }
+    }
+
+    /*
+     * A valid request should be routed to the "retrieve" action.
+     * As we are only interested in routing we have not primed a fake sbr-control-api, and so the request will fail.
+     * The key for this test is that we accepted the arguments and attempted to perform a REST call - thereby
+     * generating a "server error" rather than a "client error".
+     */
+    "is processed when valid" in new Fixture {
+      val Year = "2018"
+      val Months = Seq("01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12")
+      Months.foreach { month =>
+        withClue(s"for month $month") {
+          val validPeriod = Year + month
+          val Some(futureResult) = route(app, FakeRequest(GET, s"/v1/periods/$validPeriod/crns/$ValidCompanyRefNumber"))
+
+          status(futureResult) should be(aServerError)
+        }
+      }
+    }
+  }
+}

--- a/test/it/CompaniesHouseAcceptanceSpec.scala
+++ b/test/it/CompaniesHouseAcceptanceSpec.scala
@@ -1,0 +1,300 @@
+import java.time.Month.MAY
+
+import fixture.ServerAcceptanceSpec
+import org.scalatest.{ OptionValues, Outcome }
+import play.api.http.HeaderNames.CONTENT_TYPE
+import play.api.http.Port
+import play.api.http.Status.{ BAD_REQUEST, INTERNAL_SERVER_ERROR, NOT_FOUND, OK }
+import play.api.libs.json.Json
+import play.api.libs.ws.WSClient
+import play.api.test.WsTestClient
+import play.mvc.Http.MimeTypes.JSON
+import support.matchers.HttpServerErrorStatusCodeMatcher.aServerError
+import support.wiremock.{ WireMockAdminDataApi, WireMockSbrControlApi }
+import uk.gov.ons.sbr.models.{ CompanyRefNumber, Period }
+
+class CompaniesHouseAcceptanceSpec extends ServerAcceptanceSpec with WireMockSbrControlApi with WireMockAdminDataApi with OptionValues {
+  private val TargetCompanyRefNumber = CompanyRefNumber("03007252")
+  private val TargetPeriod = Period.fromYearMonth(2018, MAY)
+
+  private val CompaniesHouseUnitLinksResponseBody =
+    s"""|{"id":"${TargetCompanyRefNumber.value}",
+        | "parents": {
+        |   "ENT":"1000000012",
+        |   "LEU":"1111111110123456"
+        | },
+        | "unitType":"CH",
+        | "period":"${Period.asString(TargetPeriod)}"
+        |}""".stripMargin
+
+  private val CompaniesHouseUnitResponseBody =
+    s"""|{"period":"${Period.asString(TargetPeriod)}",
+        | "id":"${TargetCompanyRefNumber.value}",
+        | "variables": {
+        |   "companyname":"HOME AND LEGACY INSURANCE SERVICES LIMITED",
+        |   "companynumber":"${TargetCompanyRefNumber.value}",
+        |   "regaddress_careof":"",
+        |   "regaddress_pobox":"",
+        |   "regaddress_addressline1":"57 LADYMEAD",
+        |   "regaddress_addressline2":"",
+        |   "regaddress_posttown":"GUILDFORD",
+        |   "regaddress_county":"SURREY",
+        |   "regaddress_country":"",
+        |   "regaddress_postcode":"GU1 1DB",
+        |   "companycategory":"Private Limited Company",
+        |   "companystatus":"Active",
+        |   "countryoforigin":"United Kingdom",
+        |   "dissolutiondate":"",
+        |   "incorporationdate":"09/01/1995",
+        |   "accounts_accountrefday":"31",
+        |   "accounts_accountrefmonth":"12",
+        |   "accounts_nextduedate":"30/09/2018",
+        |   "accounts_lastmadeupdate":"31/12/2016",
+        |   "accounts_accountcategory":"FULL",
+        |   "returns_nextduedate":"06/02/2017",
+        |   "returns_lastmadeupdate":"09/01/2016",
+        |   "mortgages_nummortcharges":"6",
+        |   "mortgages_nummortoutstanding":"0",
+        |   "mortgages_nummortpartsatisfied":"0",
+        |   "mortgages_nummortsatisfied":"6",
+        |   "siccode_sictext_1":"66220 - Activities of insurance agents and brokers",
+        |   "siccode_sictext_2":"",
+        |   "siccode_sictext_3":"",
+        |   "siccode_sictext_4":"",
+        |   "limitedpartnerships_numgenpartners":"0",
+        |   "limitedpartnerships_numlimpartners":"0",
+        |   "uri":"http://business.data.gov.uk/id/company/03007252",
+        |   "previousname_1_condate":"",
+        |   "previousname_1_companyname":"",
+        |   "previousname_2_condate":"",
+        |   "previousname_2_companyname":"",
+        |   "previousname_3_condate":"",
+        |   "previousname_3_companyname":"",
+        |   "previousname_4_condate":"",
+        |   "previousname_4_companyname":"",
+        |   "previousname_5_condate":"",
+        |   "previousname_5_companyname":"",
+        |   "previousname_6_condate":"",
+        |   "previousname_6_companyname":"",
+        |   "previousname_7_condate":"",
+        |   "previousname_7_companyname":"",
+        |   "previousname_8_condate":"",
+        |   "previousname_8_companyname":"",
+        |   "previousname_9_condate":"",
+        |   "previousname_9_companyname":"",
+        |   "previousname_10_condate":"",
+        |   "previousname_10_companyname":"",
+        |   "confstmtnextduedate":"24/01/2018",
+        |   "confstmtlastmadeupdate":"10/01/2017",
+        |   "ref_period":"201706"
+        | }
+        |}""".stripMargin
+
+  private val ExpectedDetailsBody =
+    s"""
+       |{"id":"${TargetCompanyRefNumber.value}",
+       | "parents": {
+       |   "ENT":"1000000012",
+       |   "LEU":"1111111110123456"
+       | },
+       | "unitType":"CH",
+       | "period":"${Period.asString(TargetPeriod)}",
+       | "vars": {
+       |   "companyname":"HOME AND LEGACY INSURANCE SERVICES LIMITED",
+       |   "companynumber":"${TargetCompanyRefNumber.value}",
+       |   "regaddress_careof":"",
+       |   "regaddress_pobox":"",
+       |   "regaddress_addressline1":"57 LADYMEAD",
+       |   "regaddress_addressline2":"",
+       |   "regaddress_posttown":"GUILDFORD",
+       |   "regaddress_county":"SURREY",
+       |   "regaddress_country":"",
+       |   "regaddress_postcode":"GU1 1DB",
+       |   "companycategory":"Private Limited Company",
+       |   "companystatus":"Active",
+       |   "countryoforigin":"United Kingdom",
+       |   "dissolutiondate":"",
+       |   "incorporationdate":"09/01/1995",
+       |   "accounts_accountrefday":"31",
+       |   "accounts_accountrefmonth":"12",
+       |   "accounts_nextduedate":"30/09/2018",
+       |   "accounts_lastmadeupdate":"31/12/2016",
+       |   "accounts_accountcategory":"FULL",
+       |   "returns_nextduedate":"06/02/2017",
+       |   "returns_lastmadeupdate":"09/01/2016",
+       |   "mortgages_nummortcharges":"6",
+       |   "mortgages_nummortoutstanding":"0",
+       |   "mortgages_nummortpartsatisfied":"0",
+       |   "mortgages_nummortsatisfied":"6",
+       |   "siccode_sictext_1":"66220 - Activities of insurance agents and brokers",
+       |   "siccode_sictext_2":"",
+       |   "siccode_sictext_3":"",
+       |   "siccode_sictext_4":"",
+       |   "limitedpartnerships_numgenpartners":"0",
+       |   "limitedpartnerships_numlimpartners":"0",
+       |   "uri":"http://business.data.gov.uk/id/company/03007252",
+       |   "previousname_1_condate":"",
+       |   "previousname_1_companyname":"",
+       |   "previousname_2_condate":"",
+       |   "previousname_2_companyname":"",
+       |   "previousname_3_condate":"",
+       |   "previousname_3_companyname":"",
+       |   "previousname_4_condate":"",
+       |   "previousname_4_companyname":"",
+       |   "previousname_5_condate":"",
+       |   "previousname_5_companyname":"",
+       |   "previousname_6_condate":"",
+       |   "previousname_6_companyname":"",
+       |   "previousname_7_condate":"",
+       |   "previousname_7_companyname":"",
+       |   "previousname_8_condate":"",
+       |   "previousname_8_companyname":"",
+       |   "previousname_9_condate":"",
+       |   "previousname_9_companyname":"",
+       |   "previousname_10_condate":"",
+       |   "previousname_10_companyname":"",
+       |   "confstmtnextduedate":"24/01/2018",
+       |   "confstmtlastmadeupdate":"10/01/2017",
+       |   "ref_period":"201706"
+       | }
+       |}"""".stripMargin
+
+  override type FixtureParam = WSClient
+
+  override protected def withFixture(test: OneArgTest): Outcome =
+    withWireMockSbrControlApi { () =>
+      withWireMockAdminDataApi { () =>
+        WsTestClient.withClient { wsClient =>
+          withFixture(test.toNoArgTest(wsClient))
+        }(new Port(port))
+      }
+    }
+
+  info("As a SBR user")
+  info("I want to retrieve Companies House unit details for a period in time")
+  info("So that I can view Companies House unit details via the user interface")
+
+  feature("retrieve existing Companies House unit details") {
+    scenario("by company reference number for a specific period") { wsClient =>
+      Given(s"a unit link exists for a unit with $TargetCompanyRefNumber for $TargetPeriod")
+      stubSbrControlApiFor(aCompaniesHouseUnitLinksRequest(withCompanyRefNumber = TargetCompanyRefNumber, withPeriod = TargetPeriod).willReturn(
+        anOkResponse().withBody(CompaniesHouseUnitLinksResponseBody)
+      ))
+      And(s"Companies House admin data exists with $TargetCompanyRefNumber for $TargetPeriod")
+      stubAdminDataApiFor(aCompaniesHouseForPeriodRequest(withCompanyRefNumber = TargetCompanyRefNumber, withPeriod = TargetPeriod).willReturn(
+        anOkResponse().withBody(CompaniesHouseUnitResponseBody)
+      ))
+
+      When(s"the Companies House unit data with $TargetCompanyRefNumber is requested for $TargetPeriod")
+      val response = await(wsClient.url(s"/v1/periods/${Period.asString(TargetPeriod)}/crns/${TargetCompanyRefNumber.value}").get())
+
+      Then(s"the details of the Companies House unit with $TargetCompanyRefNumber for $TargetPeriod are returned")
+      response.status shouldBe OK
+      response.header(CONTENT_TYPE).value shouldBe JSON
+      response.json shouldBe Json.parse(ExpectedDetailsBody)
+    }
+  }
+
+  feature("retrieve non-existent Companies House unit details") {
+    scenario("when there is no Companies House admin data with the specified company reference number and period") { wsClient =>
+      Given(s"a unit link exists for a unit with $TargetCompanyRefNumber for $TargetPeriod")
+      stubSbrControlApiFor(aCompaniesHouseUnitLinksRequest(withCompanyRefNumber = TargetCompanyRefNumber, withPeriod = TargetPeriod).willReturn(
+        anOkResponse().withBody(CompaniesHouseUnitLinksResponseBody)
+      ))
+      And(s"Companies House admin data does not exist with $TargetCompanyRefNumber for $TargetPeriod")
+      stubAdminDataApiFor(aCompaniesHouseForPeriodRequest(withCompanyRefNumber = TargetCompanyRefNumber, withPeriod = TargetPeriod).willReturn(
+        aNotFoundResponse()
+      ))
+
+      When(s"the Companies House unit data with $TargetCompanyRefNumber is requested for $TargetPeriod")
+      val response = await(wsClient.url(s"/v1/periods/${Period.asString(TargetPeriod)}/crns/${TargetCompanyRefNumber.value}").get())
+
+      Then("a NOT FOUND response is returned")
+      response.status shouldBe NOT_FOUND
+    }
+
+    scenario("when there are no unit links defined for the specified Companies House company reference number and period") { wsClient =>
+      Given(s"a unit link does not exist for a unit with $TargetCompanyRefNumber for $TargetPeriod")
+      stubSbrControlApiFor(aCompaniesHouseUnitLinksRequest(withCompanyRefNumber = TargetCompanyRefNumber, withPeriod = TargetPeriod).willReturn(
+        aNotFoundResponse()
+      ))
+
+      When(s"the Companies House unit data with $TargetCompanyRefNumber is requested for $TargetPeriod")
+      val response = await(wsClient.url(s"/v1/periods/${Period.asString(TargetPeriod)}/crns/${TargetCompanyRefNumber.value}").get())
+
+      Then("a NOT FOUND response is returned")
+      response.status shouldBe NOT_FOUND
+    }
+  }
+
+  feature("handle failure gracefully") {
+    scenario("when the retrieval of Companies House admin data returns an error") { wsClient =>
+      Given(s"a unit link exists for a unit with $TargetCompanyRefNumber for $TargetPeriod")
+      stubSbrControlApiFor(aCompaniesHouseUnitLinksRequest(withCompanyRefNumber = TargetCompanyRefNumber, withPeriod = TargetPeriod).willReturn(
+        anOkResponse().withBody(CompaniesHouseUnitLinksResponseBody)
+      ))
+      And(s"retrieval of Companies House admin data with $TargetCompanyRefNumber for $TargetPeriod will return an error")
+      stubAdminDataApiFor(aCompaniesHouseForPeriodRequest(withCompanyRefNumber = TargetCompanyRefNumber, withPeriod = TargetPeriod).willReturn(
+        anInternalServerError()
+      ))
+
+      When(s"the Companies House unit data with $TargetCompanyRefNumber is requested for $TargetPeriod")
+      val response = await(wsClient.url(s"/v1/periods/${Period.asString(TargetPeriod)}/crns/${TargetCompanyRefNumber.value}").get())
+
+      Then("an INTERNAL_SERVER_ERROR response is returned")
+      response.status shouldBe INTERNAL_SERVER_ERROR
+    }
+
+    scenario("when the retrieval of Companies House unit links returns an error") { wsClient =>
+      Given(s"retrieval of a unit with $TargetCompanyRefNumber for $TargetPeriod will return an error")
+      stubSbrControlApiFor(aCompaniesHouseUnitLinksRequest(withCompanyRefNumber = TargetCompanyRefNumber, withPeriod = TargetPeriod).willReturn(
+        anInternalServerError()
+      ))
+
+      When(s"the Companies House unit data with $TargetCompanyRefNumber is requested for $TargetPeriod")
+      val response = await(wsClient.url(s"/v1/periods/${Period.asString(TargetPeriod)}/crns/${TargetCompanyRefNumber.value}").get())
+
+      Then("an INTERNAL_SERVER_ERROR response is returned")
+      response.status shouldBe INTERNAL_SERVER_ERROR
+    }
+
+    scenario("the Companies House admin data service is unavailable") { wsClient =>
+      Given(s"a unit link exists for a unit with $TargetCompanyRefNumber for $TargetPeriod")
+      stubSbrControlApiFor(aCompaniesHouseUnitLinksRequest(withCompanyRefNumber = TargetCompanyRefNumber, withPeriod = TargetPeriod).willReturn(
+        anOkResponse().withBody(CompaniesHouseUnitLinksResponseBody)
+      ))
+      And("the Companies House admin data service is unavailable")
+      stopMockAdminDataApi()
+
+      When(s"the Companies House unit data with $TargetCompanyRefNumber is requested for $TargetPeriod")
+      val response = await(wsClient.url(s"/v1/periods/${Period.asString(TargetPeriod)}/crns/${TargetCompanyRefNumber.value}").get())
+
+      Then("a server error is returned")
+      response.status shouldBe aServerError
+    }
+
+    scenario("the sbr_control_api service is unavailable") { wsClient =>
+      Given("the sbr_control_api service is unavailable")
+      stopMockSbrControlApi()
+
+      When(s"the Companies House unit data with $TargetCompanyRefNumber is requested for $TargetPeriod")
+      val response = await(wsClient.url(s"/v1/periods/${Period.asString(TargetPeriod)}/crns/${TargetCompanyRefNumber.value}").get())
+
+      Then("a server error is returned")
+      response.status shouldBe aServerError
+    }
+  }
+
+  feature("validate request parameters") {
+    scenario("rejecting a Companies House company number that is too long") { wsClient =>
+      Given("that a Companies House company reference number is represented by an eight digit number")
+
+      When("the user requests a Companies House unit with a reference more than eight digits long")
+      val response = await(wsClient.url(s"/v1/periods/${Period.asString(TargetPeriod)}/crns/123456789").get())
+
+      Then("a BAD REQUEST response is returned")
+      response.status shouldBe BAD_REQUEST
+    }
+  }
+}
+

--- a/test/support/wiremock/WireMockAdminDataApi.scala
+++ b/test/support/wiremock/WireMockAdminDataApi.scala
@@ -3,7 +3,7 @@ package support.wiremock
 import com.github.tomakehurst.wiremock.client.MappingBuilder
 import com.github.tomakehurst.wiremock.client.WireMock.{ get, urlEqualTo }
 import com.typesafe.scalalogging.LazyLogging
-import uk.gov.ons.sbr.models.{ PayeRef, Period, VatRef }
+import uk.gov.ons.sbr.models.{ CompanyRefNumber, PayeRef, Period, VatRef }
 
 trait WireMockAdminDataApi extends ApiResponse with LazyLogging {
   val DefaultAdminDataApiPort = 9005
@@ -38,4 +38,7 @@ trait WireMockAdminDataApi extends ApiResponse with LazyLogging {
 
   def aPayeForPeriodRequest(withPayeRef: PayeRef, withPeriod: Period): MappingBuilder =
     get(urlEqualTo(s"/v1/records/${withPayeRef.value}/periods/${Period.asString(withPeriod)}"))
+
+  def aCompaniesHouseForPeriodRequest(withCompanyRefNumber: CompanyRefNumber, withPeriod: Period): MappingBuilder =
+    get(urlEqualTo(s"/v1/records/${withCompanyRefNumber.value}/periods/${Period.asString(withPeriod)}"))
 }

--- a/test/support/wiremock/WireMockSbrControlApi.scala
+++ b/test/support/wiremock/WireMockSbrControlApi.scala
@@ -47,4 +47,7 @@ trait WireMockSbrControlApi extends ApiResponse with LazyLogging {
 
   def aPayeUnitLinksRequest(withPayeRef: PayeRef, withPeriod: Period): MappingBuilder =
     get(urlEqualTo(s"/v1/periods/${Period.asString(withPeriod)}/types/PAYE/units/${withPayeRef.value}"))
+
+  def aCompaniesHouseUnitLinksRequest(withCompanyRefNumber: CompanyRefNumber, withPeriod: Period): MappingBuilder =
+    get(urlEqualTo(s"/v1/periods/${Period.asString(withPeriod)}/types/CH/units/${withCompanyRefNumber.value}"))
 }

--- a/test/unitref/CompaniesHouseUnitRefSpec.scala
+++ b/test/unitref/CompaniesHouseUnitRefSpec.scala
@@ -1,0 +1,22 @@
+package unitref
+
+import org.scalatest.{ FreeSpec, Matchers }
+import uk.gov.ons.sbr.models.UnitType.CompaniesHouse
+import uk.gov.ons.sbr.models.{ CompanyRefNumber, UnitId }
+
+class CompaniesHouseUnitRefSpec extends FreeSpec with Matchers {
+
+  "A Company Reference Number (CRN)" - {
+    "can be created from a string parameter" in {
+      CompaniesHouseUnitRef.fromString("12345678") shouldBe CompanyRefNumber("12345678")
+    }
+
+    "can be converted to a unit Identifier and unit Type pair" in {
+      CompaniesHouseUnitRef.toIdTypePair(CompanyRefNumber("12345678")) shouldBe UnitId("12345678") -> CompaniesHouse
+    }
+
+    "can be converted to a generic unit identifier" in {
+      CompaniesHouseUnitRef.toUnitId(CompanyRefNumber("12345678")) shouldBe UnitId("12345678")
+    }
+  }
+}


### PR DESCRIPTION
Refactor Companies House to share common 'admin data' approach with VAT & PAYE.
Added acceptance tests for the endpoint.

(Note that this branch is based on REG-1134 which has yet to be merged - compare against that branch to isolate the changes made here)