### PR TITLE
Miscellaneous (minor) improvements

### DIFF
--- a/app/actions/RetrieveLinkedUnitAction.scala
+++ b/app/actions/RetrieveLinkedUnitAction.scala
@@ -1,6 +1,7 @@
 package actions
 
 import actions.RetrieveLinkedUnitAction.LinkedUnitRequestActionBuilderMaker
+import com.typesafe.scalalogging.LazyLogging
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.mvc._
 import services.{ ErrorMessage, LinkedUnitService }
@@ -14,11 +15,12 @@ object RetrieveLinkedUnitAction {
   type LinkedUnitRequestActionBuilderMaker[T] = (Period, T) => ActionBuilder[LinkedUnitRequest]
 }
 
-class RetrieveLinkedUnitAction[T](linkedUnitService: LinkedUnitService[T]) extends LinkedUnitRequestActionBuilderMaker[T] {
+class RetrieveLinkedUnitAction[T](linkedUnitService: LinkedUnitService[T]) extends LinkedUnitRequestActionBuilderMaker[T] with LazyLogging {
   def apply(period: Period, unitRef: T): ActionBuilder[LinkedUnitRequest] =
     new ActionBuilder[LinkedUnitRequest] {
       override def invokeBlock[A](request: Request[A], block: LinkedUnitRequest[A] => Future[Result]): Future[Result] =
         linkedUnitService.retrieve(period, unitRef).flatMap { errorOrOptLinkedUnit =>
+          errorOrOptLinkedUnit.left.foreach(errorMessage => logger.error(errorMessage))
           block(new LinkedUnitRequest[A](errorOrOptLinkedUnit, request))
         }
     }

--- a/app/services/finder/LocalUnitFinder.scala
+++ b/app/services/finder/LocalUnitFinder.scala
@@ -28,7 +28,7 @@ class LocalUnitFinder(localUnitRepository: LocalUnitRepository, enterpriseUnitRe
     }
 
   private def onMissingParentEnterprise(lurn: Lurn): Either[ErrorMessage, Option[JsObject]] = {
-    logger.warn(s"No parent Enterprise found in the unit links for local unit [$lurn].  Unable to retrieve the Local Unit!")
+    logger.warn(s"Invalid data.  The local unit [$lurn] has Unit Links that do not contain a parent Enterprise.")
     Left(s"Unit Links for Local Unit [$lurn] is missing a parent Enterprise.")
   }
 }

--- a/app/uk/gov/ons/sbr/models/Period.scala
+++ b/app/uk/gov/ons/sbr/models/Period.scala
@@ -9,7 +9,10 @@ import utils.JsResultSupport
 
 import scala.util.Try
 
-case class Period(value: YearMonth)
+case class Period(value: YearMonth) {
+  override def toString: String =
+    this.getClass.getSimpleName + "(" + Period.asString(this) + ")"
+}
 
 object Period {
   private val FormatPattern = "uuuuMM"

--- a/test/it/fixture/ServerAcceptanceSpec.scala
+++ b/test/it/fixture/ServerAcceptanceSpec.scala
@@ -1,6 +1,17 @@
 package fixture
 
 import org.scalatestplus.play.guice.GuiceOneServerPerTest
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.{ DefaultAwaitTimeout, FutureAwaits }
 
-trait ServerAcceptanceSpec extends AcceptanceSpec with GuiceOneServerPerTest with DefaultAwaitTimeout with FutureAwaits
+trait ServerAcceptanceSpec extends AcceptanceSpec with GuiceOneServerPerTest with DefaultAwaitTimeout with FutureAwaits {
+  /*
+   * A common acceptance scenario is failure handling, and a simple approach to triggering failure conditions is
+   * to shut down the wiremock server that represents some collaborating service.
+   * For some currently unknown reason, this can result in TimeoutExceptions rather than ConnectExceptions.  In the
+   * timeout case, the connection waits for the full timeout period before failing.
+   * We therefore artificially configure a shorter timeout here, to help speed up such acceptance tests.
+   */
+  override def fakeApplication(): Application = new GuiceApplicationBuilder().configure(Map("play.ws.timeout.connection" -> "2500")).build()
+}

--- a/test/uk/gov/ons/sbr/models/PeriodSpec.scala
+++ b/test/uk/gov/ons/sbr/models/PeriodSpec.scala
@@ -51,6 +51,10 @@ class PeriodSpec extends FreeSpec with Matchers {
     "can be represented as a string" in {
       Period.asString(Period.fromYearMonth(2018, FEBRUARY)) shouldBe "201802"
     }
+
+    "has a helpful debug representation" in {
+      Period.fromYearMonth(2018, FEBRUARY).toString shouldBe "Period(201802)"
+    }
   }
 
   "A Period JSON Format" - {


### PR DESCRIPTION
* Change toString representation of Period to prevent potentially misleading test & debug output (the default representation has a hyphen separating year & month which is not actually a format we accept)
* Artificially reduce http timeout for acceptance tests in order to speed up acceptance testing of failure scenarios
* If any service returns an error (ie a Left) ensure that this is logged

Note that this PR is based off the REG-1135: Refactor Local Unit API branch.  Compare against that branch to see only the changes introduced for this PR.