### PR TITLE
REG-1250: add Zipkin tracing

### DIFF
--- a/app/TracingModule.scala
+++ b/app/TracingModule.scala
@@ -1,0 +1,50 @@
+import actions.{ TracedRequest, WithTracingAction }
+import com.google.inject.name.Names.named
+import com.google.inject.{ AbstractModule, Provides, TypeLiteral }
+import config.BaseUrlConfigLoader
+import jp.co.bizreach.trace.ZipkinTraceServiceLike
+import jp.co.bizreach.trace.play25.filter.ZipkinTraceFilter
+import play.api.Mode.{ Dev, Prod, Test }
+import play.api.mvc.{ ActionBuilder, Filter }
+import play.api.{ Configuration, Environment }
+import tracing._
+import utils.url.Url
+import zipkin.Span
+import zipkin.reporter.okhttp3.OkHttpSender
+import zipkin.reporter.{ AsyncReporter, Reporter }
+
+/*
+ * An attempt to keep all configuration relating to tracing in an isolated module, as this is not a core
+ * feature of the application.
+ */
+class TracingModule(environment: Environment, configuration: Configuration) extends AbstractModule {
+  override def configure(): Unit = {
+    bind(classOf[ZipkinTraceServiceLike]).to(classOf[ZipkinTraceService])
+    bind(classOf[Filter]).annotatedWith(named(TracingFilterName)).to(classOf[ZipkinTraceFilter])
+    bind(classOf[TraceWSClient]).to(classOf[ZipkinTraceWSClient])
+    bind(new TypeLiteral[ActionBuilder[TracedRequest]]() {}).to(classOf[WithTracingAction])
+    () // Explicitly return unit to avoid warning about discarded non-Unit value.
+  }
+
+  /*
+   * Note that we only try to send the trace to a Zipkin server if the application is running in "production" mode.
+   * This allows developers to easily run the application without a Zipkin server (traces will be printed to the console).
+   * We wrap the "real reporter" with one that cleans-up span names by removing regex definitions.
+   */
+  @Provides
+  def providesZipkinReporter: Reporter[Span] =
+    new SpanNameCleaningReporter(delegateZipkinReporter)
+
+  private def delegateZipkinReporter: Reporter[Span] =
+    environment.mode match {
+      case Dev => Reporter.CONSOLE
+      case Test => Reporter.CONSOLE
+      case Prod => zipkinHttpReporter
+    }
+
+  private def zipkinHttpReporter: Reporter[Span] = {
+    val baseUrl = BaseUrlConfigLoader.load(configuration.underlying, "trace.zipkin.reporter")
+    val reporterUrl = Url(withBase = baseUrl, withPath = "/api/v1/spans")
+    AsyncReporter.builder(OkHttpSender.create(reporterUrl)).build()
+  }
+}

--- a/app/actions/WithTracingAction.scala
+++ b/app/actions/WithTracingAction.scala
@@ -1,0 +1,26 @@
+package actions
+
+import brave.Span
+import javax.inject.Inject
+import jp.co.bizreach.trace.ZipkinTraceServiceLike
+import jp.co.bizreach.trace.play25.implicits.ZipkinTraceImplicits
+import play.api.mvc.{ ActionBuilder, ActionTransformer, Request, WrappedRequest }
+import tracing.TraceData
+
+import scala.concurrent.Future
+
+class TracedRequest[A](val traceData: TraceData, originalRequest: Request[A]) extends WrappedRequest[A](originalRequest)
+
+class WithTracingAction @Inject() (val tracer: ZipkinTraceServiceLike) extends ActionBuilder[TracedRequest] with ActionTransformer[Request, TracedRequest] with ZipkinTraceImplicits {
+  override protected def transform[A](request: Request[A]): Future[TracedRequest[A]] =
+    Future.successful(newRequestWithTraceData(request))
+
+  private def newRequestWithTraceData[A](request: Request[A]): TracedRequest[A] = {
+    val span = request2trace(request).span
+    val traceData = new TraceData {
+      override def asSpan: Span =
+        span
+    }
+    new TracedRequest[A](traceData, request)
+  }
+}

--- a/app/controllers/v1/CompaniesHouseController.scala
+++ b/app/controllers/v1/CompaniesHouseController.scala
@@ -1,11 +1,12 @@
 package controllers.v1
 
-import actions.RetrieveLinkedUnitAction.LinkedUnitRequestActionBuilderMaker
+import actions.RetrieveLinkedUnitAction.LinkedUnitTracedRequestActionFunctionMaker
+import actions.TracedRequest
 import handlers.LinkedUnitRetrievalHandler
 import io.swagger.annotations.{ Api, _ }
 import javax.inject.{ Inject, Singleton }
 import play.api.libs.json.JsObject
-import play.api.mvc.{ Action, AnyContent, Result }
+import play.api.mvc.{ Action, ActionBuilder, AnyContent, Result }
 import uk.gov.ons.sbr.models.{ CompanyRefNumber, Period, UnitId, UnitType }
 import unitref.UnitRef
 
@@ -13,9 +14,10 @@ import unitref.UnitRef
 @Singleton
 class CompaniesHouseController @Inject() (
     unitRefType: UnitRef[CompanyRefNumber],
-    retrieveLinkedUnitAction: LinkedUnitRequestActionBuilderMaker[CompanyRefNumber],
+    tracingAction: ActionBuilder[TracedRequest],
+    retrieveLinkedUnitAction: LinkedUnitTracedRequestActionFunctionMaker[CompanyRefNumber],
     handleLinkedUnitRetrievalResult: LinkedUnitRetrievalHandler[Result]
-) extends LinkedUnitController[CompanyRefNumber](unitRefType, retrieveLinkedUnitAction, handleLinkedUnitRetrievalResult) {
+) extends LinkedUnitController[CompanyRefNumber](unitRefType, tracingAction, retrieveLinkedUnitAction, handleLinkedUnitRetrievalResult) {
   @ApiOperation(
     value = "Json representation of the Companies House unit along with its links to other units",
     notes = "parents represent a mapping from a parent unitType to the associated unit identifier; " +

--- a/app/controllers/v1/EnterpriseController.scala
+++ b/app/controllers/v1/EnterpriseController.scala
@@ -1,6 +1,7 @@
 package controllers.v1
 
-import actions.RetrieveLinkedUnitAction.LinkedUnitRequestActionBuilderMaker
+import actions.RetrieveLinkedUnitAction.LinkedUnitTracedRequestActionFunctionMaker
+import actions.TracedRequest
 import handlers.LinkedUnitRetrievalHandler
 import io.swagger.annotations._
 import javax.inject.{ Inject, Singleton }
@@ -13,9 +14,10 @@ import unitref.UnitRef
 @Singleton
 class EnterpriseController @Inject() (
     unitRefType: UnitRef[Ern],
-    retrieveLinkedUnitAction: LinkedUnitRequestActionBuilderMaker[Ern],
+    tracingAction: ActionBuilder[TracedRequest],
+    retrieveLinkedUnitAction: LinkedUnitTracedRequestActionFunctionMaker[Ern],
     handleLinkedUnitRetrievalResult: LinkedUnitRetrievalHandler[Result]
-) extends LinkedUnitController[Ern](unitRefType, retrieveLinkedUnitAction, handleLinkedUnitRetrievalResult) {
+) extends LinkedUnitController[Ern](unitRefType, tracingAction, retrieveLinkedUnitAction, handleLinkedUnitRetrievalResult) {
   @ApiOperation(
     value = "Json representation of the enterprise along with its links to other units",
     notes = "children represents a mapping from each child's unique identifier to the associated unitType; " +

--- a/app/controllers/v1/LocalUnitController.scala
+++ b/app/controllers/v1/LocalUnitController.scala
@@ -1,11 +1,12 @@
 package controllers.v1
 
-import actions.RetrieveLinkedUnitAction.LinkedUnitRequestActionBuilderMaker
+import actions.RetrieveLinkedUnitAction.LinkedUnitTracedRequestActionFunctionMaker
+import actions.TracedRequest
 import handlers.LinkedUnitRetrievalHandler
 import io.swagger.annotations.{ Api, _ }
 import javax.inject.{ Inject, Singleton }
 import play.api.libs.json.JsObject
-import play.api.mvc.{ Action, AnyContent, Result }
+import play.api.mvc.{ Action, ActionBuilder, AnyContent, Result }
 import uk.gov.ons.sbr.models.{ Lurn, Period, UnitId, UnitType }
 import unitref.UnitRef
 
@@ -13,9 +14,10 @@ import unitref.UnitRef
 @Singleton
 class LocalUnitController @Inject() (
     unitRefType: UnitRef[Lurn],
-    retrieveLinkedUnitAction: LinkedUnitRequestActionBuilderMaker[Lurn],
+    tracingAction: ActionBuilder[TracedRequest],
+    retrieveLinkedUnitAction: LinkedUnitTracedRequestActionFunctionMaker[Lurn],
     handleLinkedUnitRetrievalResult: LinkedUnitRetrievalHandler[Result]
-) extends LinkedUnitController[Lurn](unitRefType, retrieveLinkedUnitAction, handleLinkedUnitRetrievalResult) {
+) extends LinkedUnitController[Lurn](unitRefType, tracingAction, retrieveLinkedUnitAction, handleLinkedUnitRetrievalResult) {
   @ApiOperation(
     value = "Json representation of the local unit along with its links to other units",
     notes = "parents represent a mapping from the parent unitType to its associated unique identifier; " +

--- a/app/controllers/v1/PayeController.scala
+++ b/app/controllers/v1/PayeController.scala
@@ -1,11 +1,12 @@
 package controllers.v1
 
-import actions.RetrieveLinkedUnitAction.LinkedUnitRequestActionBuilderMaker
+import actions.RetrieveLinkedUnitAction.LinkedUnitTracedRequestActionFunctionMaker
+import actions.TracedRequest
 import handlers.LinkedUnitRetrievalHandler
 import io.swagger.annotations._
 import javax.inject.{ Inject, Singleton }
 import play.api.libs.json.JsObject
-import play.api.mvc.{ Action, AnyContent, Result }
+import play.api.mvc.{ Action, ActionBuilder, AnyContent, Result }
 import uk.gov.ons.sbr.models.{ PayeRef, Period, UnitId, UnitType }
 import unitref.UnitRef
 
@@ -13,9 +14,10 @@ import unitref.UnitRef
 @Singleton
 class PayeController @Inject() (
     unitRefType: UnitRef[PayeRef],
-    retrieveLinkedUnitAction: LinkedUnitRequestActionBuilderMaker[PayeRef],
+    tracingAction: ActionBuilder[TracedRequest],
+    retrieveLinkedUnitAction: LinkedUnitTracedRequestActionFunctionMaker[PayeRef],
     handleLinkedUnitRetrievalResult: LinkedUnitRetrievalHandler[Result]
-) extends LinkedUnitController[PayeRef](unitRefType, retrieveLinkedUnitAction, handleLinkedUnitRetrievalResult) {
+) extends LinkedUnitController[PayeRef](unitRefType, tracingAction, retrieveLinkedUnitAction, handleLinkedUnitRetrievalResult) {
   @ApiOperation(
     value = "Json representation of the PAYE unit along with its links to other units",
     notes = "parents represent a mapping from a parent unitType to the associated unit identifier; " +

--- a/app/controllers/v1/ReportingUnitController.scala
+++ b/app/controllers/v1/ReportingUnitController.scala
@@ -1,11 +1,12 @@
 package controllers.v1
 
-import actions.RetrieveLinkedUnitAction.LinkedUnitRequestActionBuilderMaker
+import actions.RetrieveLinkedUnitAction.LinkedUnitTracedRequestActionFunctionMaker
+import actions.TracedRequest
 import handlers.LinkedUnitRetrievalHandler
 import io.swagger.annotations._
 import javax.inject.{ Inject, Singleton }
 import play.api.libs.json.JsObject
-import play.api.mvc.{ Action, AnyContent, Result }
+import play.api.mvc.{ Action, ActionBuilder, AnyContent, Result }
 import uk.gov.ons.sbr.models.{ Period, Rurn, UnitId, UnitType }
 import unitref.UnitRef
 
@@ -13,13 +14,14 @@ import unitref.UnitRef
 @Singleton
 class ReportingUnitController @Inject() (
     unitRefType: UnitRef[Rurn],
-    retrieveLinkedUnitAction: LinkedUnitRequestActionBuilderMaker[Rurn],
+    tracingAction: ActionBuilder[TracedRequest],
+    retrieveLinkedUnitAction: LinkedUnitTracedRequestActionFunctionMaker[Rurn],
     handleLinkedUnitRetrievalResult: LinkedUnitRetrievalHandler[Result]
-) extends LinkedUnitController[Rurn](unitRefType, retrieveLinkedUnitAction, handleLinkedUnitRetrievalResult) {
+) extends LinkedUnitController[Rurn](unitRefType, tracingAction, retrieveLinkedUnitAction, handleLinkedUnitRetrievalResult) {
   @ApiOperation(
     value = "Json representation of the reporting unit along with its links to other units",
     notes = "parents represent a mapping from the parent unitType to its associated unique identifier; children represent a mapping from a unique identifier to the associated child unitType; " +
-      "vars simply passes through the representation of the unit received from the control API (and so is not defined here)",
+    "vars simply passes through the representation of the unit received from the control API (and so is not defined here)",
     response = classOf[reportingunit.examples.ReportingLinkedUnitForSwagger],
     code = 200,
     httpMethod = "GET"

--- a/app/controllers/v1/VatController.scala
+++ b/app/controllers/v1/VatController.scala
@@ -1,11 +1,12 @@
 package controllers.v1
 
-import actions.RetrieveLinkedUnitAction.LinkedUnitRequestActionBuilderMaker
+import actions.RetrieveLinkedUnitAction.LinkedUnitTracedRequestActionFunctionMaker
+import actions.TracedRequest
 import handlers.LinkedUnitRetrievalHandler
 import io.swagger.annotations._
 import javax.inject.{ Inject, Singleton }
 import play.api.libs.json.JsObject
-import play.api.mvc.{ Action, AnyContent, Result }
+import play.api.mvc.{ Action, ActionBuilder, AnyContent, Result }
 import uk.gov.ons.sbr.models.{ Period, UnitId, UnitType, _ }
 import unitref.UnitRef
 
@@ -13,9 +14,10 @@ import unitref.UnitRef
 @Singleton
 class VatController @Inject() (
     unitRefType: UnitRef[VatRef],
-    retrieveLinkedUnitAction: LinkedUnitRequestActionBuilderMaker[VatRef],
+    tracingAction: ActionBuilder[TracedRequest],
+    retrieveLinkedUnitAction: LinkedUnitTracedRequestActionFunctionMaker[VatRef],
     handleLinkedUnitRetrievalResult: LinkedUnitRetrievalHandler[Result]
-) extends LinkedUnitController[VatRef](unitRefType, retrieveLinkedUnitAction, handleLinkedUnitRetrievalResult) {
+) extends LinkedUnitController[VatRef](unitRefType, tracingAction, retrieveLinkedUnitAction, handleLinkedUnitRetrievalResult) {
   @ApiOperation(
     value = "Json representation of the VAT unit along with its links to other units",
     notes = "parents represent a mapping from a parent unitType to the associated unit identifier; " +

--- a/app/filters/Filters.scala
+++ b/app/filters/Filters.scala
@@ -1,11 +1,14 @@
 package filters
 
-import javax.inject.Inject
+import javax.inject.{ Inject, Named }
 import play.api.http.DefaultHttpFilters
+import play.api.mvc.Filter
 import play.filters.gzip.GzipFilter
+import tracing.TracingFilterName
 
 class Filters @Inject() (
-  gzipFilter: GzipFilter,
   responseTimeHeader: XResponseTimeHeaderFilter,
-  accessLoggingFilter: AccessLoggingFilter
-) extends DefaultHttpFilters(gzipFilter, responseTimeHeader, accessLoggingFilter)
+  accessLoggingFilter: AccessLoggingFilter,
+  @Named(TracingFilterName) traceFilter: Filter,
+  gzipFilter: GzipFilter
+) extends DefaultHttpFilters(responseTimeHeader, traceFilter, accessLoggingFilter, gzipFilter)

--- a/app/repository/AdminDataRepository.scala
+++ b/app/repository/AdminDataRepository.scala
@@ -1,9 +1,10 @@
 package repository
 
+import tracing.TraceData
 import uk.gov.ons.sbr.models.{ AdminData, Period, UnitId }
 
 import scala.concurrent.Future
 
 trait AdminDataRepository {
-  def retrieveAdminData(unitId: UnitId, period: Period): Future[Either[ErrorMessage, Option[AdminData]]]
+  def retrieveAdminData(unitId: UnitId, period: Period, traceData: TraceData): Future[Either[ErrorMessage, Option[AdminData]]]
 }

--- a/app/repository/EnterpriseRepository.scala
+++ b/app/repository/EnterpriseRepository.scala
@@ -1,10 +1,11 @@
 package repository
 
 import play.api.libs.json.JsObject
+import tracing.TraceData
 import uk.gov.ons.sbr.models.{ Ern, Period }
 
 import scala.concurrent.Future
 
 trait EnterpriseRepository {
-  def retrieveEnterprise(period: Period, ern: Ern): Future[Either[ErrorMessage, Option[JsObject]]]
+  def retrieveEnterprise(period: Period, ern: Ern, traceData: TraceData): Future[Either[ErrorMessage, Option[JsObject]]]
 }

--- a/app/repository/LocalUnitRepository.scala
+++ b/app/repository/LocalUnitRepository.scala
@@ -1,10 +1,11 @@
 package repository
 
 import play.api.libs.json.JsObject
+import tracing.TraceData
 import uk.gov.ons.sbr.models.{ Ern, Lurn, Period }
 
 import scala.concurrent.Future
 
 trait LocalUnitRepository {
-  def retrieveLocalUnit(period: Period, ern: Ern, lurn: Lurn): Future[Either[ErrorMessage, Option[JsObject]]]
+  def retrieveLocalUnit(period: Period, ern: Ern, lurn: Lurn, traceData: TraceData): Future[Either[ErrorMessage, Option[JsObject]]]
 }

--- a/app/repository/ReportingUnitRepository.scala
+++ b/app/repository/ReportingUnitRepository.scala
@@ -1,10 +1,11 @@
 package repository
 
 import play.api.libs.json.JsObject
+import tracing.TraceData
 import uk.gov.ons.sbr.models.{ Ern, Period, Rurn }
 
 import scala.concurrent.Future
 
 trait ReportingUnitRepository {
-  def retrieveReportingUnit(period: Period, ern: Ern, rurn: Rurn): Future[Either[ErrorMessage, Option[JsObject]]]
+  def retrieveReportingUnit(period: Period, ern: Ern, rurn: Rurn, traceData: TraceData): Future[Either[ErrorMessage, Option[JsObject]]]
 }

--- a/app/repository/UnitLinksRepository.scala
+++ b/app/repository/UnitLinksRepository.scala
@@ -1,9 +1,10 @@
 package repository
 
+import tracing.TraceData
 import uk.gov.ons.sbr.models._
 
 import scala.concurrent.Future
 
 trait UnitLinksRepository {
-  def retrieveUnitLinks(unitId: UnitId, unitType: UnitType, period: Period): Future[Either[ErrorMessage, Option[UnitLinks]]]
+  def retrieveUnitLinks(unitId: UnitId, unitType: UnitType, period: Period, traceData: TraceData): Future[Either[ErrorMessage, Option[UnitLinks]]]
 }

--- a/app/repository/admindata/RestAdminDataRepository.scala
+++ b/app/repository/admindata/RestAdminDataRepository.scala
@@ -5,15 +5,16 @@ import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.json.Reads
 import repository.rest.{ Repository, RepositoryResult }
 import repository.{ AdminDataRepository, ErrorMessage }
+import tracing.TraceData
 import uk.gov.ons.sbr.models.{ AdminData, Period, UnitId }
 
 import scala.concurrent.Future
 
-class RestAdminDataRepository(unitRepository: Repository, readsAdminData: Reads[AdminData]) extends AdminDataRepository with LazyLogging {
-  override def retrieveAdminData(unitId: UnitId, period: Period): Future[Either[ErrorMessage, Option[AdminData]]] = {
+class RestAdminDataRepository(unitRepository: Repository, readsAdminData: Reads[AdminData], adminDataType: String) extends AdminDataRepository with LazyLogging {
+  override def retrieveAdminData(unitId: UnitId, period: Period, traceData: TraceData): Future[Either[ErrorMessage, Option[AdminData]]] = {
     val path = AdminDataPath(unitId, period)
-    logger.debug(s"Requesting Admin Data with path [$path].")
-    unitRepository.getJson(path).map {
+    logger.debug(s"Requesting Admin Data [$adminDataType] with path [$path].")
+    unitRepository.getJson(path, spanName = s"get-admin-data-$adminDataType", traceData).map {
       RepositoryResult.as(readsAdminData)(_)
     }
   }

--- a/app/repository/rest/Repository.scala
+++ b/app/repository/rest/Repository.scala
@@ -2,9 +2,10 @@ package repository.rest
 
 import play.api.libs.json.JsValue
 import repository.ErrorMessage
+import tracing.TraceData
 
 import scala.concurrent.Future
 
 trait Repository {
-  def getJson(path: String): Future[Either[ErrorMessage, Option[JsValue]]]
+  def getJson(path: String, spanName: String, traceData: TraceData): Future[Either[ErrorMessage, Option[JsValue]]]
 }

--- a/app/repository/sbrctrl/RestEnterpriseRepository.scala
+++ b/app/repository/sbrctrl/RestEnterpriseRepository.scala
@@ -7,15 +7,16 @@ import play.api.libs.json.{ JsObject, Reads }
 import repository.DataSourceNames.SbrCtrl
 import repository.rest.{ Repository, RepositoryResult }
 import repository.{ EnterpriseRepository, ErrorMessage }
+import tracing.TraceData
 import uk.gov.ons.sbr.models.{ Ern, Period }
 
 import scala.concurrent.Future
 
 class RestEnterpriseRepository @Inject() (@Named(SbrCtrl) unitRepository: Repository) extends EnterpriseRepository with LazyLogging {
-  override def retrieveEnterprise(period: Period, ern: Ern): Future[Either[ErrorMessage, Option[JsObject]]] = {
+  override def retrieveEnterprise(period: Period, ern: Ern, traceData: TraceData): Future[Either[ErrorMessage, Option[JsObject]]] = {
     val path = EnterprisePath(period, ern)
     logger.debug(s"Requesting enterprise with path [$path]")
-    unitRepository.getJson(path).map {
+    unitRepository.getJson(path, spanName = "get-enterprise", traceData).map {
       RepositoryResult.as(Reads.JsObjectReads)(_)
     }
   }

--- a/app/repository/sbrctrl/RestLocalUnitRepository.scala
+++ b/app/repository/sbrctrl/RestLocalUnitRepository.scala
@@ -7,15 +7,16 @@ import play.api.libs.json.{ JsObject, Reads }
 import repository.DataSourceNames.SbrCtrl
 import repository.rest.{ Repository, RepositoryResult }
 import repository.{ ErrorMessage, LocalUnitRepository }
+import tracing.TraceData
 import uk.gov.ons.sbr.models.{ Ern, Lurn, Period }
 
 import scala.concurrent.Future
 
 class RestLocalUnitRepository @Inject() (@Named(SbrCtrl) unitRepository: Repository) extends LocalUnitRepository with LazyLogging {
-  override def retrieveLocalUnit(period: Period, ern: Ern, lurn: Lurn): Future[Either[ErrorMessage, Option[JsObject]]] = {
+  override def retrieveLocalUnit(period: Period, ern: Ern, lurn: Lurn, traceData: TraceData): Future[Either[ErrorMessage, Option[JsObject]]] = {
     val path = LocalUnitPath(period, ern, lurn)
     logger.debug(s"Requesting local unit with path [$path]")
-    unitRepository.getJson(path).map {
+    unitRepository.getJson(path, spanName = "get-local-unit", traceData).map {
       RepositoryResult.as(Reads.JsObjectReads)(_)
     }
   }

--- a/app/repository/sbrctrl/RestReportingUnitRepository.scala
+++ b/app/repository/sbrctrl/RestReportingUnitRepository.scala
@@ -7,15 +7,16 @@ import play.api.libs.json.{ JsObject, Reads }
 import repository.DataSourceNames.SbrCtrl
 import repository.rest.{ Repository, RepositoryResult }
 import repository.{ ErrorMessage, ReportingUnitRepository }
+import tracing.TraceData
 import uk.gov.ons.sbr.models.{ Ern, Period, Rurn }
 
 import scala.concurrent.Future
 
 class RestReportingUnitRepository @Inject() (@Named(SbrCtrl) unitRepository: Repository) extends ReportingUnitRepository with LazyLogging {
-  override def retrieveReportingUnit(period: Period, ern: Ern, rurn: Rurn): Future[Either[ErrorMessage, Option[JsObject]]] = {
+  override def retrieveReportingUnit(period: Period, ern: Ern, rurn: Rurn, traceData: TraceData): Future[Either[ErrorMessage, Option[JsObject]]] = {
     val path = ReportingUnitPath(period, ern, rurn)
     logger.debug(s"Requesting reporting unit with path [$path]")
-    unitRepository.getJson(path).map {
+    unitRepository.getJson(path, spanName = "get-reporting-unit", traceData).map {
       RepositoryResult.as(Reads.JsObjectReads)(_)
     }
   }

--- a/app/repository/sbrctrl/RestUnitLinksRepository.scala
+++ b/app/repository/sbrctrl/RestUnitLinksRepository.scala
@@ -7,15 +7,16 @@ import play.api.libs.json.Reads
 import repository.DataSourceNames.SbrCtrl
 import repository.rest.{ Repository, RepositoryResult }
 import repository.{ ErrorMessage, UnitLinksRepository }
+import tracing.TraceData
 import uk.gov.ons.sbr.models.{ Period, UnitId, UnitLinks, UnitType }
 
 import scala.concurrent.Future
 
 class RestUnitLinksRepository @Inject() (@Named(SbrCtrl) unitRepository: Repository, readsUnitLinks: Reads[UnitLinks]) extends UnitLinksRepository with LazyLogging {
-  override def retrieveUnitLinks(unitId: UnitId, unitType: UnitType, period: Period): Future[Either[ErrorMessage, Option[UnitLinks]]] = {
+  override def retrieveUnitLinks(unitId: UnitId, unitType: UnitType, period: Period, traceData: TraceData): Future[Either[ErrorMessage, Option[UnitLinks]]] = {
     val path = UnitLinksPath(unitId, unitType, period)
     logger.debug(s"Requesting Unit Links with path [$path].")
-    unitRepository.getJson(path).map {
+    unitRepository.getJson(path, spanName = "get-unit-links", traceData).map {
       RepositoryResult.as(readsUnitLinks)(_)
     }
   }

--- a/app/services/LinkedUnitService.scala
+++ b/app/services/LinkedUnitService.scala
@@ -1,9 +1,10 @@
 package services
 
+import tracing.TraceData
 import uk.gov.ons.sbr.models.{ LinkedUnit, Period }
 
 import scala.concurrent.Future
 
 trait LinkedUnitService[T] {
-  def retrieve(period: Period, unitRef: T): Future[Either[ErrorMessage, Option[LinkedUnit]]]
+  def retrieve(period: Period, unitRef: T, traceData: TraceData): Future[Either[ErrorMessage, Option[LinkedUnit]]]
 }

--- a/app/services/RestLinkedUnitService.scala
+++ b/app/services/RestLinkedUnitService.scala
@@ -4,6 +4,7 @@ import com.typesafe.scalalogging.LazyLogging
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import repository.UnitLinksRepository
 import services.finder.UnitFinder
+import tracing.TraceData
 import uk.gov.ons.sbr.models.{ LinkedUnit, Period, UnitLinks }
 import unitref.UnitRef
 
@@ -15,13 +16,13 @@ class RestLinkedUnitService[T](
     unitFinder: UnitFinder[T]
 ) extends LinkedUnitService[T] with LazyLogging {
 
-  override def retrieve(period: Period, unitRef: T): Future[Either[ErrorMessage, Option[LinkedUnit]]] = {
+  override def retrieve(period: Period, unitRef: T, traceData: TraceData): Future[Either[ErrorMessage, Option[LinkedUnit]]] = {
     val (unitId, unitType) = unitRefType.toIdTypePair(unitRef)
-    unitLinksRepository.retrieveUnitLinks(unitId, unitType, period).flatMap { errorOrUnitLinks =>
+    unitLinksRepository.retrieveUnitLinks(unitId, unitType, period, traceData).flatMap { errorOrUnitLinks =>
       errorOrUnitLinks.fold(
         err => Future.successful(Left(err)),
         optUnitLinks => optUnitLinks.fold(onUnitLinksNotFound(period, unitRef)) { unitLinks =>
-          onUnitLinksFound(period, unitRef, unitLinks)
+          onUnitLinksFound(period, unitRef, unitLinks, traceData)
         }
       )
     }
@@ -32,9 +33,9 @@ class RestLinkedUnitService[T](
     Future.successful(Right(None))
   }
 
-  private def onUnitLinksFound(period: Period, unitRef: T, unitLinks: UnitLinks): Future[Either[ErrorMessage, Option[LinkedUnit]]] = {
+  private def onUnitLinksFound(period: Period, unitRef: T, unitLinks: UnitLinks, traceData: TraceData): Future[Either[ErrorMessage, Option[LinkedUnit]]] = {
     logger.debug(s"Found Unit Links for [$period] and [$unitRef].  Attempting to find unit ...")
-    unitFinder.find(period, unitRef, unitLinks).map { errorOrJson =>
+    unitFinder.find(period, unitRef, unitLinks, traceData).map { errorOrJson =>
       errorOrJson.right.map { optJson =>
         if (optJson.isEmpty) logger.warn(s"Inconsistent Database.  No unit found for [$period] and [$unitRef] that has Unit Links [$unitLinks].")
         optJson.map { json =>

--- a/app/services/finder/AdminDataFinder.scala
+++ b/app/services/finder/AdminDataFinder.scala
@@ -4,14 +4,15 @@ import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.json.JsObject
 import repository.AdminDataRepository
 import services.ErrorMessage
+import tracing.TraceData
 import uk.gov.ons.sbr.models.{ Period, UnitLinks }
 import unitref.UnitRef
 
 import scala.concurrent.Future
 
 class AdminDataFinder[T](unitRefType: UnitRef[T], adminDataRepository: AdminDataRepository) extends UnitFinder[T] {
-  override def find(period: Period, unitRef: T, unitLinks: UnitLinks): Future[Either[ErrorMessage, Option[JsObject]]] =
-    adminDataRepository.retrieveAdminData(unitRefType.toUnitId(unitRef), period).map { errorOrAdminData =>
+  override def find(period: Period, unitRef: T, unitLinks: UnitLinks, traceData: TraceData): Future[Either[ErrorMessage, Option[JsObject]]] =
+    adminDataRepository.retrieveAdminData(unitRefType.toUnitId(unitRef), period, traceData).map { errorOrAdminData =>
       errorOrAdminData.right.map { optAdminData =>
         optAdminData.map(_.variables)
       }

--- a/app/services/finder/EnterpriseFinder.scala
+++ b/app/services/finder/EnterpriseFinder.scala
@@ -3,11 +3,12 @@ package services.finder
 import play.api.libs.json.JsObject
 import repository.EnterpriseRepository
 import services.ErrorMessage
+import tracing.TraceData
 import uk.gov.ons.sbr.models.{ Ern, Period, UnitLinks }
 
 import scala.concurrent.Future
 
 class EnterpriseFinder(enterpriseRepository: EnterpriseRepository) extends UnitFinder[Ern] {
-  override def find(period: Period, unitRef: Ern, unitLinks: UnitLinks): Future[Either[ErrorMessage, Option[JsObject]]] =
-    enterpriseRepository.retrieveEnterprise(period, unitRef)
+  override def find(period: Period, unitRef: Ern, unitLinks: UnitLinks, traceData: TraceData): Future[Either[ErrorMessage, Option[JsObject]]] =
+    enterpriseRepository.retrieveEnterprise(period, unitRef, traceData)
 }

--- a/app/services/finder/UnitFinder.scala
+++ b/app/services/finder/UnitFinder.scala
@@ -2,10 +2,11 @@ package services.finder
 
 import play.api.libs.json.JsObject
 import services.ErrorMessage
+import tracing.TraceData
 import uk.gov.ons.sbr.models.{ Period, UnitLinks }
 
 import scala.concurrent.Future
 
 trait UnitFinder[T] {
-  def find(period: Period, unitRef: T, unitLinks: UnitLinks): Future[Either[ErrorMessage, Option[JsObject]]]
+  def find(period: Period, unitRef: T, unitLinks: UnitLinks, traceData: TraceData): Future[Either[ErrorMessage, Option[JsObject]]]
 }

--- a/app/tracing/SpanNameCleaningReporter.scala
+++ b/app/tracing/SpanNameCleaningReporter.scala
@@ -1,0 +1,38 @@
+package tracing
+
+import tracing.SpanNameCleaningReporter.regexPathParam
+import zipkin.Span
+import zipkin.reporter.Reporter
+
+/*
+ * A Zipkin Reporter that "cleans up" spanNames by removing regex definitions and then forwards the modified span
+ * to a delegate reporter.
+ */
+class SpanNameCleaningReporter(delegate: Reporter[Span]) extends Reporter[Span] {
+  override def report(span: Span): Unit =
+    delegate.report(modifySpan(span))
+
+  private def modifySpan(span: Span): Span = {
+    val builder = span.toBuilder
+    builder.name(withoutRegex(span.name)).build()
+  }
+
+  /*
+   * Strip any regular expressions from dynamic routes, converting $id<regex> to $id.
+   */
+  private def withoutRegex(name: String): String = {
+    val params = regexPathParam.findAllIn(name)
+    params.matchData.foldLeft(name) { (acc, param) =>
+      acc.replace(param.matched, param.group(1))
+    }
+  }
+}
+
+object SpanNameCleaningReporter {
+  /*
+   * We want to convert $id<regex> to $id.
+   * \$[^<]+ is the $id component.  We make a capturing group for this by wrapping in parentheses (\$[^<]+)
+   * <[^>]+> is the <regex> component.
+   */
+  private val regexPathParam = """(\$[^<]+)<[^>]+>""".r
+}

--- a/app/tracing/TraceData.scala
+++ b/app/tracing/TraceData.scala
@@ -1,0 +1,7 @@
+package tracing
+
+import brave.Span
+
+trait TraceData {
+  def asSpan: Span
+}

--- a/app/tracing/TraceWSClient.scala
+++ b/app/tracing/TraceWSClient.scala
@@ -1,0 +1,26 @@
+package tracing
+
+import java.io.{ Closeable, IOException }
+
+import play.api.libs.ws.WSRequest
+
+/*
+ * While play-zipkin-tracing provides a tracing wsClient, it provides only a concrete class and no associated trait.
+ * Using the play-zipkin-tracing component directly would:
+ * - limit our implementation options going forwards
+ * - prevent us from being able to use mocks in tests (we do not mock concrete classes with scalamock).
+ *   (note that we already have tests that are written against a mock Play wsClient - as the Play WSClient separates
+ *    the interface from the implementation)
+ *
+ * We therefore provide our own trait for this behaviour, and provide an implementation that simply wraps the
+ * play-zipkin-tracing implementation.
+ *
+ * @see tracing.ZipkinTraceWSClient
+ * @see play.api.libs.ws.WSClient
+  */
+trait TraceWSClient extends Closeable {
+  def url(url: String, spanName: String, traceData: TraceData): WSRequest
+
+  /** Closes this client, and releases underlying resources. */
+  @throws[IOException] def close(): Unit
+}

--- a/app/tracing/ZipkinTraceService.scala
+++ b/app/tracing/ZipkinTraceService.scala
@@ -1,0 +1,34 @@
+package tracing
+
+import akka.actor.ActorSystem
+import brave.Tracing
+import brave.sampler.Sampler
+import brave.sampler.Sampler.ALWAYS_SAMPLE
+import javax.inject.{ Inject, Singleton }
+import jp.co.bizreach.trace.ZipkinTraceConfig.{ AkkaName, ZipkinSampleRate }
+import jp.co.bizreach.trace.ZipkinTraceServiceLike
+import play.api.Configuration
+import zipkin.Span
+import zipkin.reporter.Reporter
+
+import scala.concurrent.ExecutionContext
+
+/*
+ * This is based on jp.co.bizreach.trace.play25.ZipkinTraceService from play-zipkin-tracing.
+ * The key difference is that we inject a reporter for flexibility, rather than hard-coding an asynchronous HTTP reporter.
+ */
+@Singleton
+class ZipkinTraceService @Inject() (conf: Configuration, actorSystem: ActorSystem, reporter: Reporter[Span]) extends ZipkinTraceServiceLike {
+  override implicit val executionContext: ExecutionContext = actorSystem.dispatchers.lookup(AkkaName)
+
+  override val tracing: Tracing = Tracing.newBuilder()
+    .localServiceName("sbr-api")
+    .reporter(reporter)
+    .sampler(samplerFrom(conf))
+    .build()
+
+  private def samplerFrom(conf: Configuration): Sampler = {
+    val sampleRateOpt = conf.getString(ZipkinSampleRate).map(_.toFloat)
+    sampleRateOpt.fold(ALWAYS_SAMPLE)(Sampler.create)
+  }
+}

--- a/app/tracing/ZipkinTraceWSClient.scala
+++ b/app/tracing/ZipkinTraceWSClient.scala
@@ -1,0 +1,17 @@
+package tracing
+import java.io.IOException
+
+import javax.inject.Inject
+import play.api.libs.ws.WSRequest
+
+/*
+ * This class simply wraps the play-zipkin-tracing implementation with our own trait.
+ */
+class ZipkinTraceWSClient @Inject() (wsClient: jp.co.bizreach.trace.play25.TraceWSClient) extends TraceWSClient {
+  override def url(url: String, spanName: String, traceData: TraceData): WSRequest =
+    wsClient.url(spanName, url)(jp.co.bizreach.trace.TraceData(traceData.asSpan))
+
+  /** Closes this client, and releases underlying resources. */
+  @throws[IOException] override def close(): Unit =
+    wsClient.close()
+}

--- a/app/tracing/package.scala
+++ b/app/tracing/package.scala
@@ -1,0 +1,5 @@
+
+package object tracing {
+  // must be final to generate byte-code that will be considered "constant" so that we can use this with @Named annotation
+  final val TracingFilterName = "trace-filter"
+}

--- a/build.sbt
+++ b/build.sbt
@@ -147,8 +147,9 @@ lazy val devDeps = Seq(
   "io.swagger"                   %%    "swagger-play2"       %    "1.5.3",
   "io.lemonlabs"                 %%    "scala-uri"           %    "0.5.0",
   "org.webjars"                  %     "swagger-ui"          %    "3.1.4",
-  "com.typesafe"                 %      "config"             %    "1.3.1"
-    excludeAll ExclusionRule("commons-logging", "commons-logging")
+  "com.typesafe"                 %     "config"              %    "1.3.1"
+    excludeAll ExclusionRule("commons-logging", "commons-logging"),
+  "jp.co.bizreach"               %%    "play-zipkin-tracing-play25" % "1.2.0"       // Zipkin v1 support (not v2)
 )
 
 /*

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -61,6 +61,7 @@ play.modules {
   # If there are any built-in modules that you want to enable, you can list them here.
   #enabled += my.application.Module
   enabled += "play.modules.swagger.SwaggerModule"
+  enabled += "TracingModule"
 
   # If there are any built-in modules that you want to disable, you can list them here.
   #disabled += ""
@@ -358,6 +359,30 @@ db {
   # You can turn on SQL logging for any datasource
   # https://www.playframework.com/documentation/latest/Highlights25#Logging-SQL-statements
   #default.logSql=true
+}
+
+// Zipkin tracing
+trace {
+  zipkin {
+    reporter {
+      protocol = "http"
+      protocol = ${?SBR_TRACING_REPORTER_PROTOCOL}
+      host = "localhost"
+      host = ${?SBR_TRACING_REPORTER_HOST}
+      port = 9411
+      port = ${?SBR_TRACING_REPORTER_PORT}
+    }
+
+    sample-rate = 1.0
+    sample-rate = ${?SBR_TRACING_SAMPLE_RATE}
+  }
+}
+
+zipkin-trace-context {
+  fork-join-executor {
+    parallelism-factor = 20.0
+    parallelism-max = 200
+  }
 }
 
 api.version = "alpha"

--- a/test/actions/WithTracingActionSpec.scala
+++ b/test/actions/WithTracingActionSpec.scala
@@ -1,0 +1,43 @@
+package actions
+
+import jp.co.bizreach.trace.ZipkinTraceServiceLike
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{ FreeSpec, Matchers }
+import play.api.mvc.Results.Ok
+import play.api.mvc.{ AnyContent, Result }
+import play.api.test.FakeRequest
+import support.tracing.FakeTracing
+
+import scala.concurrent.Future
+
+class WithTracingActionSpec extends FreeSpec with Matchers with MockFactory with ScalaFutures with FakeTracing {
+
+  private trait Fixture {
+    val TraceIdHigh = 0xb787a0cecda09171L
+    val TraceIdLow = 0x694e46a737dc1097L
+    val ParentSpanId = 0xa642df366ccebdb8L
+    val SpanId = 0x2b5a2554fdf088f2L
+
+    val block = mockFunction[TracedRequest[AnyContent], Future[Result]]
+    val traceService: ZipkinTraceServiceLike = new StubTraceService(fakeSpan(TraceIdHigh, TraceIdLow, ParentSpanId, SpanId))
+    val tracingAction = new WithTracingAction(traceService)
+  }
+
+  "WithTracingAction" - {
+    "adds TraceData to the request" in new Fixture {
+      val request = FakeRequest("GET", "/some-uri")
+
+      block.expects(where(aRequestWithTraceData[AnyContent](
+        withTraceIdHigh = TraceIdHigh,
+        withTraceIdLow = TraceIdLow,
+        withParentSpanId = ParentSpanId,
+        withSpanId = SpanId
+      ))).returns(Future.successful(Ok))
+
+      whenReady(tracingAction.invokeBlock(request, block)) { result =>
+        result shouldBe Ok
+      }
+    }
+  }
+}

--- a/test/filters/AccessLoggingFilterSpec.scala
+++ b/test/filters/AccessLoggingFilterSpec.scala
@@ -1,0 +1,46 @@
+package filters
+
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.{ FreeSpec, Matchers }
+import play.api.mvc.{ Headers, RequestHeader, ResponseHeader }
+
+class AccessLoggingFilterSpec extends FreeSpec with Matchers with MockFactory {
+
+  private trait Fixture {
+    val RequestMethod = "GET"
+    val RequestUri = "/v1/periods/201806/ents/1234567890"
+    val RequestRemoteAddress = "127.0.0.1"
+
+    val requestHeader = stub[RequestHeader]
+  }
+
+  "An Access Log formatter" - {
+    "builds an access log entry for an access event" - {
+      "when Zipkin tracing headers are available" in new Fixture {
+        val headers = new Headers(Seq(
+          "X-B3-TraceId" -> "7ccace5dd505a64eaccb2f9d1a9a4739",
+          "X-B3-SpanId" -> "6b2e08a9748184c9",
+          "X-B3-ParentSpanId" -> "a58971547454d3dd"
+        ))
+        (requestHeader.headers _).when().returns(headers)
+        (requestHeader.method _).when().returns(RequestMethod)
+        (requestHeader.uri _).when().returns(RequestUri)
+        (requestHeader.remoteAddress _).when().returns(RequestRemoteAddress)
+
+        AccessLogFormatter(requestHeader, new ResponseHeader(status = 200)) shouldBe
+          "traceId=[7ccace5dd505a64eaccb2f9d1a9a4739] parentSpanId=[a58971547454d3dd] spanId=[6b2e08a9748184c9] method=[GET] uri=[/v1/periods/201806/ents/1234567890] remote-address=[127.0.0.1] status=[200]"
+      }
+
+      "when Zipkin tracing headers are not available" in new Fixture {
+        val headers = new Headers(Seq.empty)
+        (requestHeader.headers _).when().returns(headers)
+        (requestHeader.method _).when().returns(RequestMethod)
+        (requestHeader.uri _).when().returns(RequestUri)
+        (requestHeader.remoteAddress _).when().returns(RequestRemoteAddress)
+
+        AccessLogFormatter(requestHeader, new ResponseHeader(status = 200)) shouldBe
+          "traceId=[none] parentSpanId=[none] spanId=[none] method=[GET] uri=[/v1/periods/201806/ents/1234567890] remote-address=[127.0.0.1] status=[200]"
+      }
+    }
+  }
+}

--- a/test/it/TracingAcceptanceSpec.scala
+++ b/test/it/TracingAcceptanceSpec.scala
@@ -1,0 +1,282 @@
+
+import java.time.Month.JUNE
+
+import TracingAcceptanceSpec.SpanMatcher.{ aChildSpan, aRootSpan }
+import TracingAcceptanceSpec._
+import com.google.inject.{ AbstractModule, TypeLiteral }
+import com.typesafe.scalalogging.LazyLogging
+import fixture.ServerAcceptanceSpec
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.{ Millis, Seconds }
+import org.scalatest.{ Outcome, TestData }
+import play.api.Application
+import play.api.http.Port
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.ws.WSClient
+import play.api.test.WsTestClient
+import support.wiremock.WireMockSbrControlApi
+import tracing.SpanNameCleaningReporter
+import uk.gov.ons.sbr.models.{ Ern, Period }
+import zipkin.Span
+import zipkin.reporter.Reporter
+
+import scala.collection._
+
+class TracingAcceptanceSpec extends ServerAcceptanceSpec with MockFactory with WireMockSbrControlApi with ScalaFutures {
+
+  // We want a fresh reporter per test, but need to retain a handle on the instance for assertion purposes.
+  private var traceReporter: Reporter[Span] = _
+  private val reportedSpans: mutable.ListBuffer[Span] = mutable.ListBuffer.empty
+
+  override implicit val patienceConfig: PatienceConfig = PatienceConfig(
+    timeout = scaled(org.scalatest.time.Span(10, Seconds)),
+    interval = scaled(org.scalatest.time.Span(500, Millis))
+  )
+
+  override def newAppForTest(testData: TestData): Application = {
+    /*
+     * We actually need a "spy", because when a root traceId is auto-allocated we need to capture the value
+     * so that we can assert that child spans share the traceId.
+     * ScalaMock does not provide "spy" support, so we emulate it by capturing all reported spans in our own
+     * mutable collection.
+     */
+    reportedSpans.clear()
+    traceReporter = stub[Reporter[Span]]
+    (traceReporter.report _).when(*).onCall { (span: Span) =>
+      reportedSpans += span
+      ()
+    }
+
+    val fakeTracingModule = new AbstractModule {
+      override def configure(): Unit = {
+        bind(new TypeLiteral[Reporter[Span]]() {}).toInstance(new DebugReporter(new SpanNameCleaningReporter(traceReporter)))
+      }
+    }
+
+    new GuiceApplicationBuilder().overrides(fakeTracingModule).build()
+  }
+
+  override type FixtureParam = WSClient
+
+  override protected def withFixture(test: OneArgTest): Outcome =
+    withWireMockSbrControlApi { () =>
+      WsTestClient.withClient { wsClient =>
+        withFixture(test.toNoArgTest(wsClient))
+      }(new Port(port))
+    }
+
+  info("As a DevOps engineer")
+  info("I want to be able to trace all calls made to sbr-api")
+  info("So that I can debug and trace requests")
+
+  feature("a trace is created for incoming requests that are missing a trace context") {
+    scenario("when serving the request does not entail making downstream requests") { wsClient =>
+      Given("the request will have no existing trace context")
+      val timestampMicrosBeforeRequest = currentTimestampMicros
+
+      When(s"a request is made for the sbr-api version")
+      whenReady(wsClient.url("/version").get()) { _ =>
+
+        Then(s"a root trace span is created to capture the request latency")
+        (traceReporter.report _).verify(where(aRootSpan(
+          withName = "get - /version",
+          withTimestampMicrosAfter = timestampMicrosBeforeRequest
+        )))
+
+        And("no other spans are created")
+        reportedSpans should have length 1
+      }
+    }
+
+    scenario("when serving the request entails making downstream requests") { wsClient =>
+      Given(s"a downstream unit link request will find the unit links")
+      stubSbrControlApiFor(anEnterpriseUnitLinksRequest(withErn = TargetErn, withPeriod = TargetPeriod).willReturn(
+        anOkResponse().withBody(unitLinksResponseBody(TargetErn, TargetPeriod))
+      ))
+      And(s"a downstream unit request will find the unit")
+      stubSbrControlApiFor(anEnterpriseForPeriodRequest(withErn = TargetErn, withPeriod = TargetPeriod).willReturn(
+        anOkResponse().withBody(unitResponseBody(TargetErn))
+      ))
+      And("the incoming request will have no existing trace context")
+      val timestampMicrosBeforeRequest = currentTimestampMicros
+
+      When(s"a request is made to retrieve a unit")
+      whenReady(wsClient.url(s"/v1/periods/${Period.asString(TargetPeriod)}/ents/${TargetErn.value}").get()) { _ =>
+
+        Then(s"a root trace span is created to capture the overall request latency")
+        (traceReporter.report _).verify(where(aRootSpan(
+          withName = "get - /v1/periods/$period/ents/$ern",
+          withTimestampMicrosAfter = timestampMicrosBeforeRequest
+        )))
+        val parentSpan = singletonSpanByName(reportedSpans.toList, name = "get - /v1/periods/$period/ents/$ern")
+
+        And(s"a child trace span is created to capture the unit links request latency")
+        (traceReporter.report _).verify(where(aChildSpan(
+          withParentSpan = parentSpan,
+          withName = "get-unit-links",
+          withTimestampMicrosAfter = timestampMicrosBeforeRequest
+        )))
+
+        And(s"a child trace span is created to capture the unit request latency")
+        (traceReporter.report _).verify(where(aChildSpan(
+          withParentSpan = parentSpan,
+          withName = "get-enterprise",
+          withTimestampMicrosAfter = timestampMicrosBeforeRequest
+        )))
+
+        And("no other spans are created")
+        reportedSpans should have length 3
+      }
+    }
+  }
+
+  feature("a span is created for incoming requests that have an existing trace context") {
+    scenario("when serving the request does not entail making downstream requests") { wsClient =>
+      Given("the request will have a trace context")
+      val traceContext = makeTraceContext(RequestTraceIdHigh, RequestTraceIdLow, RequestSpanId)
+      val timestampMicrosBeforeRequest = currentTimestampMicros
+
+      When(s"a request is made for the sbr-api version")
+      whenReady(wsClient.url("/version").withHeaders(traceContext: _*).get()) { _ =>
+
+        Then(s"a child span is created within the existing trace to capture the request latency")
+        (traceReporter.report _).verify(where(aChildSpan(
+          withTraceIdHigh = RequestTraceIdHigh,
+          withTraceIdLow = RequestTraceIdLow,
+          withParentSpanId = RequestSpanId,
+          withName = "get - /version",
+          withTimestampMicrosAfter = timestampMicrosBeforeRequest
+        )))
+
+        And("no other spans are created")
+        reportedSpans should have length 1
+      }
+    }
+
+    scenario("when serving the request entails making downstream requests") { wsClient =>
+      Given(s"a downstream unit link request will find the unit links")
+      stubSbrControlApiFor(anEnterpriseUnitLinksRequest(withErn = TargetErn, withPeriod = TargetPeriod).willReturn(
+        anOkResponse().withBody(unitLinksResponseBody(TargetErn, TargetPeriod))
+      ))
+      And(s"a downstream unit request will find the unit")
+      stubSbrControlApiFor(anEnterpriseForPeriodRequest(withErn = TargetErn, withPeriod = TargetPeriod).willReturn(
+        anOkResponse().withBody(unitResponseBody(TargetErn))
+      ))
+      And("the incoming request will have a trace context")
+      val traceContext = makeTraceContext(RequestTraceIdHigh, RequestTraceIdLow, RequestSpanId)
+      val timestampMicrosBeforeRequest = currentTimestampMicros
+
+      When(s"a request is made to retrieve a unit")
+      whenReady(wsClient.url(s"/v1/periods/${Period.asString(TargetPeriod)}/ents/${TargetErn.value}").withHeaders(traceContext: _*).get()) { _ =>
+
+        Then(s"a child span is created within the existing trace to capture the request latency")
+        (traceReporter.report _).verify(where(aChildSpan(
+          withTraceIdHigh = RequestTraceIdHigh,
+          withTraceIdLow = RequestTraceIdLow,
+          withParentSpanId = RequestSpanId,
+          withName = "get - /v1/periods/$period/ents/$ern",
+          withTimestampMicrosAfter = timestampMicrosBeforeRequest
+        )))
+        val parentSpan = singletonSpanByName(reportedSpans.toList, name = "get - /v1/periods/$period/ents/$ern")
+
+        And(s"a grandchild span is created within the existing trace to capture the unit links request latency")
+        (traceReporter.report _).verify(where(aChildSpan(
+          withParentSpan = parentSpan,
+          withName = "get-unit-links",
+          withTimestampMicrosAfter = timestampMicrosBeforeRequest
+        )))
+
+        And(s"a grandchild span is created within the existing trace to capture the unit request latency")
+        (traceReporter.report _).verify(where(aChildSpan(
+          withParentSpan = parentSpan,
+          withName = "get-enterprise",
+          withTimestampMicrosAfter = timestampMicrosBeforeRequest
+        )))
+
+        And("no other spans are created")
+        reportedSpans should have length 3
+      }
+    }
+  }
+}
+
+object TracingAcceptanceSpec {
+  private val TargetErn = Ern("1234567890")
+  private val TargetPeriod = Period.fromYearMonth(2018, JUNE)
+  private val RequestTraceIdHigh = 0x36599d86b3de7f62L
+  private val RequestTraceIdLow = 0x71ddb90fd26ac6a3L
+  private val RequestSpanId = 0x09b5600fe57d0333L
+
+  private def unitLinksResponseBody(ern: Ern, period: Period): String =
+    s"""
+       |{"id":"${ern.value}",
+       | "children":{"10205415":"LEU","900000011":"LOU"},
+       | "unitType":"ENT",
+       | "period":"${Period.asString(period)}"
+       |}""".stripMargin
+
+  private def unitResponseBody(ern: Ern): String =
+    s"""|{
+        | "ern":"${ern.value}",
+        | "entref":"some-entref",
+        | "name":"some-name",
+        | "postcode":"some-postcode",
+        | "legalStatus":"some-legalStatus",
+        | "employees":42
+        |}""".stripMargin
+
+  private def currentTimestampMicros: Long =
+    System.currentTimeMillis() * 100L
+
+  private def makeTraceContext(traceIdHigh: Long, traceIdLow: Long, spanId: Long): List[(String, String)] =
+    List(
+      ("X-B3-TraceId", traceIdHigh.toHexString + traceIdLow.toHexString),
+      ("X-B3-SpanId", spanId.toHexString)
+    )
+
+  private def singletonSpanByName(spans: List[Span], name: String): Span = {
+    val matchingSpans = spans.filter(_.name == name)
+    if (matchingSpans.length != 1) throw new AssertionError(s"Expected a single span with name [$name] but there was [${matchingSpans.length}]")
+    matchingSpans.head
+  }
+
+  object SpanMatcher {
+    def aRootSpan(withName: String, withTimestampMicrosAfter: Long): Span => Boolean =
+      (span: Span) =>
+        span.parentId == null &&
+          span.name == withName &&
+          span.timestamp > withTimestampMicrosAfter &&
+          span.duration > 0L
+
+    def aChildSpan(withParentSpan: Span, withName: String, withTimestampMicrosAfter: Long): Span => Boolean =
+      aChildSpan(
+        withTraceIdHigh = withParentSpan.traceIdHigh,
+        withTraceIdLow = withParentSpan.traceId,
+        withParentSpanId = withParentSpan.id,
+        withName,
+        withTimestampMicrosAfter
+      )
+
+    def aChildSpan(withTraceIdHigh: Long, withTraceIdLow: Long, withParentSpanId: Long,
+      withName: String, withTimestampMicrosAfter: Long): Span => Boolean =
+      (span: Span) =>
+        span.traceIdHigh == withTraceIdHigh &&
+          span.traceId == withTraceIdLow &&
+          span.parentId == withParentSpanId &&
+          span.name == withName &&
+          span.timestamp > withTimestampMicrosAfter &&
+          span.duration > 0L &&
+          span.id != span.parentId
+  }
+
+  /*
+   * This is just here to facilitate seeing the span when working on this test.
+   */
+  private class DebugReporter(delegate: Reporter[Span]) extends Reporter[Span] with LazyLogging {
+    override def report(span: Span): Unit = {
+      logger.debug(s"Reported Span [$span]")
+      delegate.report(span)
+    }
+  }
+}

--- a/test/repository/rest/RestRepository_MockClientSpec.scala
+++ b/test/repository/rest/RestRepository_MockClientSpec.scala
@@ -3,7 +3,8 @@ package repository.rest
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{ EitherValues, FreeSpec, Matchers }
-import play.api.libs.ws.{ WSClient, WSRequest, WSResponse }
+import play.api.libs.ws.{ WSRequest, WSResponse }
+import tracing.{ TraceData, TraceWSClient }
 import utils.url.BaseUrl
 import utils.url.BaseUrl.Protocol.Http
 
@@ -19,8 +20,10 @@ class RestRepository_MockClientSpec extends FreeSpec with Matchers with MockFact
 
   private trait Fixture {
     val SomeRelativePath = "foo/bar/baz"
+    val SomeSpanName = "span-name"
 
-    val wsClient = stub[WSClient]
+    val wsClient = stub[TraceWSClient]
+    val traceData = stub[TraceData]
     val wsRequest = mock[WSRequest]
     val config = RestRepositoryConfig(
       BaseUrl(protocol = Http, host = "somehost", port = 4321)
@@ -32,10 +35,10 @@ class RestRepository_MockClientSpec extends FreeSpec with Matchers with MockFact
 
   "A SBR Control unit repository" - {
     "targets the specified host and port when making a request" in new Fixture {
-      (wsClient.url _).when(s"http://somehost:4321/$SomeRelativePath").returning(wsRequest)
+      (wsClient.url _).when(s"http://somehost:4321/$SomeRelativePath", SomeSpanName, traceData).returning(wsRequest)
       (wsRequest.get _).expects().returning(Future.successful(stub[WSResponse]))
 
-      repository.getJson(SomeRelativePath)
+      repository.getJson(SomeRelativePath, SomeSpanName, traceData)
     }
 
     /*
@@ -43,10 +46,10 @@ class RestRepository_MockClientSpec extends FreeSpec with Matchers with MockFact
      * Future failing.  This tests the "catch-all" case, and that we can effectively recover the Future.
      */
     "materialises a failure into an error message" in new Fixture {
-      (wsClient.url _).when(*).returns(wsRequest)
+      (wsClient.url _).when(*, SomeSpanName, traceData).returns(wsRequest)
       (wsRequest.get _).expects().returning(Future.failed(new Exception("Connection failed")))
 
-      whenReady(repository.getJson(SomeRelativePath)) { result =>
+      whenReady(repository.getJson(SomeRelativePath, SomeSpanName, traceData)) { result =>
         result.left.value shouldBe "Connection failed"
       }
     }

--- a/test/repository/rest/RestRepository_WiremockSpec.scala
+++ b/test/repository/rest/RestRepository_WiremockSpec.scala
@@ -1,6 +1,8 @@
 package repository.rest
 
+import brave.propagation.TraceContext
 import com.github.tomakehurst.wiremock.client.WireMock.{ aResponse, get, urlEqualTo }
+import jp.co.bizreach.trace.ZipkinTraceServiceLike
 import org.scalamock.scalatest.MockFactory
 import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
@@ -10,16 +12,31 @@ import play.api.Application
 import play.api.http.Status.{ BAD_REQUEST, SERVICE_UNAVAILABLE }
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.Json
-import play.api.libs.ws.WSClient
 import support.wiremock.WireMockSbrControlApi
+import tracing.{ TraceData, TraceWSClient }
 import utils.url.BaseUrl
 import utils.url.BaseUrl.Protocol.Http
 
 class RestRepository_WiremockSpec extends org.scalatest.fixture.FreeSpec with GuiceOneAppPerSuite with WireMockSbrControlApi with Matchers with ScalaFutures with EitherValues with MockFactory {
 
   private val SomePath = "foo/bar/baz"
+  private val SomeSpanName = "span-name"
+  private val SomeTraceData = stub[TraceData]
   private val SomeJsonStr = s"""{"message":"Hello World!"}"""
   private val RequestTimeoutMillis = 100
+
+  /*
+   * Turn off auto-verification of mocks inherited from AbstractMockFactory.
+   *
+   * With auto-verification enabled this test will fail with:
+   *   assertion failed: Null expectation context - missing withExpectations?
+   *   java.lang.AssertionError: assertion failed: Null expectation context - missing withExpectations?
+   * possibly as a result of the order of operations.
+   *
+   * Tracing is not part of this test, and is only involved because we have to pass TraceData to the system under test.
+   * Verification is not therefore required.
+   */
+  autoVerify = false
 
   // artificially reduce the default request timeout for the purposes of testing timeout handling.
   override def fakeApplication(): Application = new GuiceApplicationBuilder().configure("play.ws.timeout.request" -> RequestTimeoutMillis).build()
@@ -31,16 +48,21 @@ class RestRepository_WiremockSpec extends org.scalatest.fixture.FreeSpec with Gu
 
   override protected def withFixture(test: OneArgTest): Outcome =
     withWireMockSbrControlApi { () =>
-      withFixture(test.toNoArgTest(newFixtureParam))
+      withFixture {
+        (SomeTraceData.asSpan _).when().returns(fakeSpan)
+        test.toNoArgTest(newFixtureParam)
+      }
     }
 
-  /*
-   * Note that we cannot use WsTestClient here as it does not respect the request timeout settings of the app,
-   * and we want to test timeout handling behaviour.
-   */
+  private def fakeSpan: brave.Span = {
+    val traceContext = TraceContext.newBuilder().traceId(0x54c3bbc70482705fL).spanId(0xc17a932c627ba20bL).build()
+    val traceService = app.injector.instanceOf[ZipkinTraceServiceLike]
+    traceService.tracing.tracer().joinSpan(traceContext)
+  }
+
   private def newFixtureParam: FixtureParam = {
     val config = RestRepositoryConfig(BaseUrl(Http, "localhost", DefaultSbrControlApiPort))
-    val wsClient = app.injector.instanceOf[WSClient]
+    val wsClient = app.injector.instanceOf[TraceWSClient]
     FixtureParam(new RestRepository(config, wsClient))
   }
 
@@ -49,7 +71,7 @@ class RestRepository_WiremockSpec extends org.scalatest.fixture.FreeSpec with Gu
       "returns json when the resource is found" in { fixture =>
         stubSbrControlApiFor(get(urlEqualTo(s"""/$SomePath""")).willReturn(anOkResponse().withBody(SomeJsonStr)))
 
-        whenReady(fixture.repository.getJson(SomePath)) { result =>
+        whenReady(fixture.repository.getJson(SomePath, SomeSpanName, SomeTraceData)) { result =>
           result.right.value shouldBe Some(Json.parse(SomeJsonStr))
         }
       }
@@ -57,7 +79,7 @@ class RestRepository_WiremockSpec extends org.scalatest.fixture.FreeSpec with Gu
       "returns nothing when the resource is not found" in { fixture =>
         stubSbrControlApiFor(get(urlEqualTo(s"""/$SomePath""")).willReturn(aNotFoundResponse()))
 
-        whenReady(fixture.repository.getJson(SomePath)) { result =>
+        whenReady(fixture.repository.getJson(SomePath, SomeSpanName, SomeTraceData)) { result =>
           result.right.value shouldBe empty
         }
       }
@@ -67,7 +89,7 @@ class RestRepository_WiremockSpec extends org.scalatest.fixture.FreeSpec with Gu
       "when the response is a client error" in { fixture =>
         stubSbrControlApiFor(get(urlEqualTo(s"""/$SomePath""")).willReturn(aResponse().withStatus(BAD_REQUEST)))
 
-        whenReady(fixture.repository.getJson(SomePath)) { result =>
+        whenReady(fixture.repository.getJson(SomePath, SomeSpanName, SomeTraceData)) { result =>
           result.left.value shouldBe "Bad Request (400)"
         }
       }
@@ -75,7 +97,7 @@ class RestRepository_WiremockSpec extends org.scalatest.fixture.FreeSpec with Gu
       "when the response is a server error" in { fixture =>
         stubSbrControlApiFor(get(urlEqualTo(s"""/$SomePath""")).willReturn(aResponse().withStatus(SERVICE_UNAVAILABLE)))
 
-        whenReady(fixture.repository.getJson(SomePath)) { result =>
+        whenReady(fixture.repository.getJson(SomePath, SomeSpanName, SomeTraceData)) { result =>
           result.left.value shouldBe "Service Unavailable (503)"
         }
       }
@@ -83,7 +105,7 @@ class RestRepository_WiremockSpec extends org.scalatest.fixture.FreeSpec with Gu
       "when an OK response is returned containing a non-JSON body" in { fixture =>
         stubSbrControlApiFor(get(urlEqualTo(s"""/$SomePath""")).willReturn(anOkResponse().withBody("this-is-not-json")))
 
-        whenReady(fixture.repository.getJson(SomePath)) { result =>
+        whenReady(fixture.repository.getJson(SomePath, SomeSpanName, SomeTraceData)) { result =>
           result.left.value should startWith("Unable to create JsValue from unit response")
         }
       }
@@ -95,7 +117,7 @@ class RestRepository_WiremockSpec extends org.scalatest.fixture.FreeSpec with Gu
         stubSbrControlApiFor(get(urlEqualTo(s"""/$SomePath""")).willReturn(anOkResponse().withBody(SomeJsonStr).
           withFixedDelay(RequestTimeoutMillis * 2)))
 
-        whenReady(fixture.repository.getJson(SomePath)) { result =>
+        whenReady(fixture.repository.getJson(SomePath, SomeSpanName, SomeTraceData)) { result =>
           result.left.value should startWith("Timeout")
         }
       }

--- a/test/repository/sbrctrl/RestLocalUnitRepositorySpec.scala
+++ b/test/repository/sbrctrl/RestLocalUnitRepositorySpec.scala
@@ -8,6 +8,7 @@ import org.scalatest.{ EitherValues, FreeSpec, Matchers }
 import play.api.libs.json.Json
 import repository.rest.Repository
 import support.sample.SampleLocalUnit
+import tracing.TraceData
 import uk.gov.ons.sbr.models.{ Ern, Lurn, Period }
 
 import scala.concurrent.Future
@@ -19,28 +20,30 @@ class RestLocalUnitRepositorySpec extends FreeSpec with Matchers with MockFactor
     val TargetErn = Ern("9876543210")
     val TargetLurn = Lurn("123456789")
     val LocalUnitJson = SampleLocalUnit.asJson(TargetErn, TargetLurn)
+    val SpanName = "get-local-unit"
 
+    val traceData = stub[TraceData]
     val unitRepository = mock[Repository]
     val localUnitRepository = new RestLocalUnitRepository(unitRepository)
   }
 
   "A LocalUnit repository" - {
     "returns the requested local unit when found" in new Fixture {
-      (unitRepository.getJson _).expects(s"v1/enterprises/${TargetErn.value}/periods/${Period.asString(TargetPeriod)}/localunits/${TargetLurn.value}").returning(
+      (unitRepository.getJson _).expects(s"v1/enterprises/${TargetErn.value}/periods/${Period.asString(TargetPeriod)}/localunits/${TargetLurn.value}", SpanName, traceData).returning(
         Future.successful(Right(Some(LocalUnitJson)))
       )
 
-      whenReady(localUnitRepository.retrieveLocalUnit(TargetPeriod, TargetErn, TargetLurn)) { result =>
+      whenReady(localUnitRepository.retrieveLocalUnit(TargetPeriod, TargetErn, TargetLurn, traceData)) { result =>
         result.right.value shouldBe Some(LocalUnitJson)
       }
     }
 
     "returns nothing when the requested local unit is not found" in new Fixture {
-      (unitRepository.getJson _).expects(s"v1/enterprises/${TargetErn.value}/periods/${Period.asString(TargetPeriod)}/localunits/${TargetLurn.value}").returning(
+      (unitRepository.getJson _).expects(s"v1/enterprises/${TargetErn.value}/periods/${Period.asString(TargetPeriod)}/localunits/${TargetLurn.value}", SpanName, traceData).returning(
         Future.successful(Right(None))
       )
 
-      whenReady(localUnitRepository.retrieveLocalUnit(TargetPeriod, TargetErn, TargetLurn)) { result =>
+      whenReady(localUnitRepository.retrieveLocalUnit(TargetPeriod, TargetErn, TargetLurn, traceData)) { result =>
         result.right.value shouldBe empty
       }
     }
@@ -48,22 +51,22 @@ class RestLocalUnitRepositorySpec extends FreeSpec with Matchers with MockFactor
     "returns an error message" - {
       "when the retrieval fails" in new Fixture {
         val failureMessage = "some failure message"
-        (unitRepository.getJson _).expects(s"v1/enterprises/${TargetErn.value}/periods/${Period.asString(TargetPeriod)}/localunits/${TargetLurn.value}").returning(
+        (unitRepository.getJson _).expects(s"v1/enterprises/${TargetErn.value}/periods/${Period.asString(TargetPeriod)}/localunits/${TargetLurn.value}", SpanName, traceData).returning(
           Future.successful(Left(failureMessage))
         )
 
-        whenReady(localUnitRepository.retrieveLocalUnit(TargetPeriod, TargetErn, TargetLurn)) { result =>
+        whenReady(localUnitRepository.retrieveLocalUnit(TargetPeriod, TargetErn, TargetLurn, traceData)) { result =>
           result.left.value shouldBe failureMessage
         }
       }
 
       "when the JSON received is not a Json object" in new Fixture {
         val jsArray = Json.parse(s"""[{"lurn":"${TargetLurn.value}"}]""")
-        (unitRepository.getJson _).expects(s"v1/enterprises/${TargetErn.value}/periods/${Period.asString(TargetPeriod)}/localunits/${TargetLurn.value}").returning(
+        (unitRepository.getJson _).expects(s"v1/enterprises/${TargetErn.value}/periods/${Period.asString(TargetPeriod)}/localunits/${TargetLurn.value}", SpanName, traceData).returning(
           Future.successful(Right(Some(jsArray)))
         )
 
-        whenReady(localUnitRepository.retrieveLocalUnit(TargetPeriod, TargetErn, TargetLurn)) { result =>
+        whenReady(localUnitRepository.retrieveLocalUnit(TargetPeriod, TargetErn, TargetLurn, traceData)) { result =>
           result.left.value should startWith("Unable to parse json response")
         }
       }

--- a/test/repository/sbrctrl/RestReportingUnitRepositorySpec.scala
+++ b/test/repository/sbrctrl/RestReportingUnitRepositorySpec.scala
@@ -8,6 +8,7 @@ import org.scalatest.{ EitherValues, FreeSpec, Matchers }
 import play.api.libs.json.Json
 import repository.rest.Repository
 import support.sample.SampleReportingUnit
+import tracing.TraceData
 import uk.gov.ons.sbr.models.{ Ern, Period, Rurn }
 
 import scala.concurrent.Future
@@ -19,28 +20,30 @@ class RestReportingUnitRepositorySpec extends FreeSpec with Matchers with MockFa
     val TargetErn = Ern("9876543210")
     val TargetRurn = Rurn("12345678901")
     val ReportingUnitJson = SampleReportingUnit.asJson(TargetErn, TargetRurn)
+    val SpanName = "get-reporting-unit"
 
+    val traceData = stub[TraceData]
     val unitRepository = mock[Repository]
     val reportingUnitRepository = new RestReportingUnitRepository(unitRepository)
   }
 
   "A ReportingUnit repository" - {
     "returns the requested reporting unit when found" in new Fixture {
-      (unitRepository.getJson _).expects(s"v1/enterprises/${TargetErn.value}/periods/${Period.asString(TargetPeriod)}/reportingunits/${TargetRurn.value}").returning(
+      (unitRepository.getJson _).expects(s"v1/enterprises/${TargetErn.value}/periods/${Period.asString(TargetPeriod)}/reportingunits/${TargetRurn.value}", SpanName, traceData).returning(
         Future.successful(Right(Some(ReportingUnitJson)))
       )
 
-      whenReady(reportingUnitRepository.retrieveReportingUnit(TargetPeriod, TargetErn, TargetRurn)) { result =>
+      whenReady(reportingUnitRepository.retrieveReportingUnit(TargetPeriod, TargetErn, TargetRurn, traceData)) { result =>
         result.right.value shouldBe Some(ReportingUnitJson)
       }
     }
 
     "returns nothing when the requested reporting unit is not found" in new Fixture {
-      (unitRepository.getJson _).expects(s"v1/enterprises/${TargetErn.value}/periods/${Period.asString(TargetPeriod)}/reportingunits/${TargetRurn.value}").returning(
+      (unitRepository.getJson _).expects(s"v1/enterprises/${TargetErn.value}/periods/${Period.asString(TargetPeriod)}/reportingunits/${TargetRurn.value}", SpanName, traceData).returning(
         Future.successful(Right(None))
       )
 
-      whenReady(reportingUnitRepository.retrieveReportingUnit(TargetPeriod, TargetErn, TargetRurn)) { result =>
+      whenReady(reportingUnitRepository.retrieveReportingUnit(TargetPeriod, TargetErn, TargetRurn, traceData)) { result =>
         result.right.value shouldBe empty
       }
     }
@@ -48,22 +51,22 @@ class RestReportingUnitRepositorySpec extends FreeSpec with Matchers with MockFa
     "returns an error message" - {
       "when the retrieval fails" in new Fixture {
         val failureMessage = "some failure message"
-        (unitRepository.getJson _).expects(s"v1/enterprises/${TargetErn.value}/periods/${Period.asString(TargetPeriod)}/reportingunits/${TargetRurn.value}").returning(
+        (unitRepository.getJson _).expects(s"v1/enterprises/${TargetErn.value}/periods/${Period.asString(TargetPeriod)}/reportingunits/${TargetRurn.value}", SpanName, traceData).returning(
           Future.successful(Left(failureMessage))
         )
 
-        whenReady(reportingUnitRepository.retrieveReportingUnit(TargetPeriod, TargetErn, TargetRurn)) { result =>
+        whenReady(reportingUnitRepository.retrieveReportingUnit(TargetPeriod, TargetErn, TargetRurn, traceData)) { result =>
           result.left.value shouldBe failureMessage
         }
       }
 
       "when the JSON received is not a Json object" in new Fixture {
         val jsArray = Json.parse(s"""[{"rurn":"${TargetRurn.value}"}]""")
-        (unitRepository.getJson _).expects(s"v1/enterprises/${TargetErn.value}/periods/${Period.asString(TargetPeriod)}/reportingunits/${TargetRurn.value}").returning(
+        (unitRepository.getJson _).expects(s"v1/enterprises/${TargetErn.value}/periods/${Period.asString(TargetPeriod)}/reportingunits/${TargetRurn.value}", SpanName, traceData).returning(
           Future.successful(Right(Some(jsArray)))
         )
 
-        whenReady(reportingUnitRepository.retrieveReportingUnit(TargetPeriod, TargetErn, TargetRurn)) { result =>
+        whenReady(reportingUnitRepository.retrieveReportingUnit(TargetPeriod, TargetErn, TargetRurn, traceData)) { result =>
           result.left.value should startWith("Unable to parse json response")
         }
       }

--- a/test/services/finder/ByParentEnterpriseUnitFinderSpec.scala
+++ b/test/services/finder/ByParentEnterpriseUnitFinderSpec.scala
@@ -7,6 +7,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{ EitherValues, FreeSpec, Matchers }
 import play.api.libs.json.{ JsObject, Json }
 import services.ErrorMessage
+import tracing.TraceData
 import uk.gov.ons.sbr.models.UnitType.{ Enterprise, LegalUnit, ReportingUnit }
 import uk.gov.ons.sbr.models._
 import unitref.UnitRef
@@ -30,7 +31,8 @@ class ByParentEnterpriseUnitFinderSpec extends FreeSpec with Matchers with MockF
     )
     val UnitJson = Json.parse(s"""{"some":"json"}""").as[JsObject]
 
-    val retrieveUnit = mockFunction[Period, Ern, FakeRef, Future[Either[ErrorMessage, Option[JsObject]]]]
+    val traceData = stub[TraceData]
+    val retrieveUnit = mockFunction[Period, Ern, FakeRef, TraceData, Future[Either[ErrorMessage, Option[JsObject]]]]
     val enterpriseUnitRefType = stub[UnitRef[Ern]]
     (enterpriseUnitRefType.fromUnitId _).when(UnitId(ParentErn.value)).returns(ParentErn)
     val finder = new ByParentEnterpriseUnitFinder[FakeRef](retrieveUnit, enterpriseUnitRefType)
@@ -39,32 +41,32 @@ class ByParentEnterpriseUnitFinderSpec extends FreeSpec with Matchers with MockF
   "A ByParentEnterprise Unit finder" - {
     "retrieves a unit via the repository when the unit links contain a parent Enterprise" - {
       "returning the JSON representation when the unit is found" in new Fixture {
-        retrieveUnit.expects(TargetPeriod, ParentErn, TargetUnitRef).returning(
+        retrieveUnit.expects(TargetPeriod, ParentErn, TargetUnitRef, traceData).returning(
           Future.successful(Right(Some(UnitJson)))
         )
 
-        whenReady(finder.find(TargetPeriod, TargetUnitRef, TheUnitLinks)) { result =>
+        whenReady(finder.find(TargetPeriod, TargetUnitRef, TheUnitLinks, traceData)) { result =>
           result.right.value shouldBe Some(UnitJson)
         }
       }
 
       "returning nothing when the unit is not found" in new Fixture {
-        retrieveUnit.expects(TargetPeriod, ParentErn, TargetUnitRef).returning(
+        retrieveUnit.expects(TargetPeriod, ParentErn, TargetUnitRef, traceData).returning(
           Future.successful(Right(None))
         )
 
-        whenReady(finder.find(TargetPeriod, TargetUnitRef, TheUnitLinks)) { result =>
+        whenReady(finder.find(TargetPeriod, TargetUnitRef, TheUnitLinks, traceData)) { result =>
           result.right.value shouldBe empty
         }
       }
 
       "returning the failure message when the retrieval fails" in new Fixture {
         val failureMessage = "retrieval failed"
-        retrieveUnit.expects(TargetPeriod, ParentErn, TargetUnitRef).returning(
+        retrieveUnit.expects(TargetPeriod, ParentErn, TargetUnitRef, traceData).returning(
           Future.successful(Left(failureMessage))
         )
 
-        whenReady(finder.find(TargetPeriod, TargetUnitRef, TheUnitLinks)) { result =>
+        whenReady(finder.find(TargetPeriod, TargetUnitRef, TheUnitLinks, traceData)) { result =>
           result.left.value shouldBe failureMessage
         }
       }
@@ -73,7 +75,7 @@ class ByParentEnterpriseUnitFinderSpec extends FreeSpec with Matchers with MockF
     "fails when the unit links do not contain a parent Enterprise" in new Fixture {
       val unitLinksMissingParentEnterprise = TheUnitLinks.copy(parents = Some(Map(LegalUnit -> UnitId("1234567890123456"))))
 
-      whenReady(finder.find(TargetPeriod, TargetUnitRef, unitLinksMissingParentEnterprise)) { result =>
+      whenReady(finder.find(TargetPeriod, TargetUnitRef, unitLinksMissingParentEnterprise, traceData)) { result =>
         result.left.value shouldBe s"Unit Links for unit [$TargetUnitRef] is missing the mandatory parent Enterprise."
       }
     }

--- a/test/support/tracing/FakeTracing.scala
+++ b/test/support/tracing/FakeTracing.scala
@@ -1,0 +1,54 @@
+package support.tracing
+
+import actions.TracedRequest
+import brave.propagation.TraceContext
+import brave.{ Span, Tracing }
+import jp.co.bizreach.trace.ZipkinTraceServiceLike
+
+import scala.concurrent.ExecutionContext
+
+trait FakeTracing {
+  /*
+   * We cannot use scalamock for this as the key method we would need to mock/stub (toSpan) is not accessible.
+   * We therefore use a hand-cranked stub.
+   */
+  protected class StubTraceService(span: Span) extends ZipkinTraceServiceLike {
+    override implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
+    override val tracing: Tracing = Tracing.newBuilder().build()
+
+    override def toSpan[A](headers: A)(getHeader: (A, String) => Option[String]): Span =
+      span
+  }
+
+  protected def fakeSpan(traceIdHigh: Long, traceIdLow: Long, parentSpanId: Long, spanId: Long): Span = {
+    val traceContext = TraceContext.newBuilder().
+      traceIdHigh(traceIdHigh).
+      traceId(traceIdLow).
+      parentId(parentSpanId).
+      spanId(spanId).
+      build()
+    Tracing.newBuilder().build().tracer().toSpan(traceContext)
+  }
+
+  def aTraceContext(withTraceIdHigh: Long, withTraceIdLow: Long, withParentSpanId: Long, withSpanId: Long)(actual: TraceContext): Boolean = {
+    val result = actual.traceIdHigh() == withTraceIdHigh &&
+      actual.traceId() == withTraceIdLow &&
+      actual.parentId() == withParentSpanId &&
+      actual.spanId() == withSpanId
+
+    if (!result) {
+      val expected = TraceContext.newBuilder().
+        traceIdHigh(withTraceIdHigh).
+        traceId(withTraceIdLow).
+        parentId(withParentSpanId).
+        spanId(withSpanId).
+        build()
+      System.err.println(s"Expected TraceContext of [$expected] but was [$actual].")
+    }
+    result
+  }
+
+  def aRequestWithTraceData[A](withTraceIdHigh: Long, withTraceIdLow: Long, withParentSpanId: Long, withSpanId: Long): TracedRequest[A] => Boolean =
+    (tracedRequest: TracedRequest[A]) =>
+      aTraceContext(withTraceIdHigh, withTraceIdLow, withParentSpanId, withSpanId)(tracedRequest.traceData.asSpan.context())
+}

--- a/test/tracing/SpanNameCleaningReporterSpec.scala
+++ b/test/tracing/SpanNameCleaningReporterSpec.scala
@@ -1,0 +1,60 @@
+package tracing
+
+import java.lang.System.currentTimeMillis
+
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.{ FreeSpec, Matchers }
+import zipkin.Span
+import zipkin.reporter.Reporter
+
+class SpanNameCleaningReporterSpec extends FreeSpec with Matchers with MockFactory {
+
+  private trait Fixture {
+    private val spanBuilder = Span.builder().
+      traceId(1122334455L).
+      id(98765L).
+      parentId(123456L).
+      timestamp(currentTimeMillis()).
+      duration(500L).
+      debug(false)
+
+    private val delegateReporter = mock[Reporter[Span]]
+    private val reporter = new SpanNameCleaningReporter(delegateReporter)
+
+    def expectRouteGeneratesSpanWithName(route: String, spanName: String): Unit = {
+      val span = spanBuilder.name(route).build()
+
+      // expectation is only met if the spanName has been correctly modified and the spanName is the only modification
+      (delegateReporter.report _).expects(where {
+        (reportedSpan: Span) =>
+          reportedSpan.name == spanName &&
+            reportedSpan.toBuilder.name(route).build() == span
+      })
+
+      reporter.report(span)
+    }
+  }
+
+  "A SpanNameCleaningReporter" - {
+    "reports the span with an unmodified name" - {
+      "when the route definition is a static path" in new Fixture {
+        val route = "/health"
+        expectRouteGeneratesSpanWithName(route = route, spanName = route)
+      }
+
+      "when the route definition contains simple dynamic path parameters" in new Fixture {
+        val route = "/v1/periods/:period/ents/:ern"
+        expectRouteGeneratesSpanWithName(route = route, spanName = route)
+      }
+    }
+
+    "reports the span with a modified name" - {
+      "when the route definition contains dynamic path parameters with custom regular expressions" in new Fixture {
+        expectRouteGeneratesSpanWithName(
+          route = """/v1/periods/$period<\d{4}(0[1-9]|1[0-2])>/ents/$ern<\d{10}>""",
+          spanName = "/v1/periods/$period/ents/$ern"
+        )
+      }
+    }
+  }
+}

--- a/test/tracing/ZipkinTraceWSClientSpec.scala
+++ b/test/tracing/ZipkinTraceWSClientSpec.scala
@@ -1,0 +1,42 @@
+package tracing
+
+import brave.Tracing
+import brave.propagation.TraceContext
+import jp.co.bizreach.trace.ZipkinTraceServiceLike
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.{ FreeSpec, Matchers }
+import play.api.libs.ws.{ WSClient, WSRequest }
+
+class ZipkinTraceWSClientSpec extends FreeSpec with Matchers with MockFactory {
+
+  private trait Fixture {
+    val SomeUrl = "/some-url"
+
+    val wsClient = mock[WSClient]
+    val zipkinTraceServiceLike = stub[ZipkinTraceServiceLike]
+    val zipkinTraceWSClient = new jp.co.bizreach.trace.play25.TraceWSClient(wsClient, zipkinTraceServiceLike)
+
+    val wsRequest = stub[WSRequest]
+    val traceData = stub[TraceData]
+    val fakeTraceContext = TraceContext.newBuilder().traceId(0x7b1fe14fb2c02751L).spanId(0xd1409af47eb8bac8L).build()
+    (traceData.asSpan _).when().returns(Tracing.newBuilder().build().tracer().joinSpan(fakeTraceContext))
+
+    val traceWSClient = new ZipkinTraceWSClient(zipkinTraceWSClient)
+  }
+
+  "A ZipkinTraceWSClient" - {
+    "delegates to the underlying wsClient" - {
+      "url" in new Fixture {
+        (wsClient.url _).expects(SomeUrl).returning(wsRequest)
+
+        traceWSClient.url(SomeUrl, "some-span-name", traceData)
+      }
+
+      "close" in new Fixture {
+        (wsClient.close _).expects()
+
+        traceWSClient.close()
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds Zipkin tracing of inbound and downstream requests.
In particular:
* integrate ZipkinTraceFilter
* integrate TraceWSClient
* add trace / span identifiers to access log

Note that this PR does not contain any changes to have normal log statements capture the related trace / span Id.  That will be added by a subsequent change.

See JIRA for a Zipkin UI screenshot of a multi-tier span, along with the associated JSON data.